### PR TITLE
Add blacklisted tag to the message of blacklisted results

### DIFF
--- a/src/commands/lewd/danbooru.js
+++ b/src/commands/lewd/danbooru.js
@@ -31,6 +31,10 @@ function findOne(haystack, arr) {
   return arr.some(v => haystack.includes(v));
 }
 
+function getOne(haystack, arr) {
+  return arr.find(v => haystack.includes(v));
+}
+
 function tags(client, evt, suffix) {
   return getBlackListRemove(evt.message.channel_id).then(removeValue => {
     let channelTest = evt.message.channel.nsfw;
@@ -109,7 +113,8 @@ function tags(client, evt, suffix) {
                 return;
               }
               fileurl = null;
-              imageDescription = `**BLACKLISTED RESULT** | **Link:** [Click Here](http://danbooru.donmai.us/posts/${id})`;
+              let blacklistMatch = getOne(blacklist, tags);
+              imageDescription = `**BLACKLISTED RESULT** - Link Contains: ${blacklistMatch} | **Link:** [Click Here](http://danbooru.donmai.us/posts/${id})`;
             }
           }
 

--- a/src/commands/lewd/derpibooru.js
+++ b/src/commands/lewd/derpibooru.js
@@ -32,6 +32,10 @@ function findOne(haystack, arr) {
   return arr.some(v => haystack.includes(v));
 }
 
+function getOne(haystack, arr) {
+  return arr.find(v => haystack.includes(v));
+}
+
 function tags(client, evt, suffix) {
   return getBlackListRemove(evt.message.channel_id).then(removeValue => {
     let channelTest = evt.message.channel.nsfw;
@@ -122,7 +126,8 @@ function tags(client, evt, suffix) {
                 return;
               }
               fileurl = null;
-              imageDescription = `**BLACKLISTED RESULT** | **Link:** [Click Here](https://derpibooru.org/${id})`;
+              let blacklistMatch = getOne(blacklist, tags);
+              imageDescription = `**BLACKLISTED RESULT** - Link Contains: ${blacklistMatch} | **Link:** [Click Here](https://derpibooru.org/${id})`;
             }
           }
 

--- a/src/commands/lewd/e621.js
+++ b/src/commands/lewd/e621.js
@@ -31,6 +31,10 @@ function findOne(haystack, arr) {
   return arr.some(v => haystack.includes(v));
 }
 
+function getOne(haystack, arr) {
+  return arr.find(v => haystack.includes(v));
+}
+
 function tags(client, evt, suffix) {
   return getBlackListRemove(evt.message.channel_id).then(removeValue => {
     let channelTest = evt.message.channel.nsfw;
@@ -108,7 +112,8 @@ function tags(client, evt, suffix) {
                 return;
               }
               file = null;
-              imageDescription = `**BLACKLISTED RESULT** | **Link:** [Click Here](https://e621.net/post/show/${id})`;
+              let blacklistMatch = getOne(blacklist, tags);
+              imageDescription = `**BLACKLISTED RESULT** - Link Contains: ${blacklistMatch} | **Link:** [Click Here](https://e621.net/post/show/${id})`;
             }
           }
 

--- a/src/commands/lewd/e926.js
+++ b/src/commands/lewd/e926.js
@@ -31,6 +31,10 @@ function findOne(haystack, arr) {
   return arr.some(v => haystack.includes(v));
 }
 
+function getOne(haystack, arr) {
+  return arr.find(v => haystack.includes(v));
+}
+
 function tags(client, evt, suffix) {
   return getBlackListRemove(evt.message.channel_id).then(removeValue => {
     return getBlackListChannel(evt.message.channel_id).then(value => {
@@ -105,7 +109,8 @@ function tags(client, evt, suffix) {
                 return;
               }
               file = null;
-              imageDescription = `**BLACKLISTED RESULT** | **Link:** [Click Here](https://e926.net/post/show/${id})`;
+              let blacklistMatch = getOne(blacklist, tags);
+              imageDescription = `**BLACKLISTED RESULT** - Link Contains: ${blacklistMatch} | **Link:** [Click Here](https://e926.net/post/show/${id})`;
             }
           }
 

--- a/src/commands/lewd/furrybooru.js
+++ b/src/commands/lewd/furrybooru.js
@@ -31,6 +31,10 @@ function findOne(haystack, arr) {
   return arr.some(v => haystack.includes(v));
 }
 
+function getOne(haystack, arr) {
+  return arr.find(v => haystack.includes(v));
+}
+
 function tags(client, evt, suffix) {
   return getBlackListRemove(evt.message.channel_id).then(removeValue => {
     let channelTest = evt.message.channel.nsfw;
@@ -111,7 +115,8 @@ function tags(client, evt, suffix) {
                 return;
               }
               fileurl = null;
-              imageDescription = `**BLACKLISTED RESULT** | **Link:** [Click Here](http://furry.booru.org/index.php?page=post&s=view&id=${id})`;
+              let blacklistMatch = getOne(blacklist, tags);
+              imageDescription = `**BLACKLISTED RESULT** - Link Contains: ${blacklistMatch} | **Link:** [Click Here](http://furry.booru.org/index.php?page=post&s=view&id=${id})`;
             }
           }
 

--- a/src/commands/lewd/gelbooru.js
+++ b/src/commands/lewd/gelbooru.js
@@ -31,6 +31,10 @@ function findOne(haystack, arr) {
   return arr.some(v => haystack.includes(v));
 }
 
+function getOne(haystack, arr) {
+  return arr.find(v => haystack.includes(v));
+}
+
 function tags(client, evt, suffix) {
   return getBlackListRemove(evt.message.channel_id).then(removeValue => {
     let channelTest = evt.message.channel.nsfw;
@@ -111,7 +115,8 @@ function tags(client, evt, suffix) {
                 return;
               }
               fileurl = null;
-              imageDescription = `**BLACKLISTED RESULT** | **Link:** [Click Here](http://gelbooru.com/index.php?page=post&s=view&id=${id})`;
+              let blacklistMatch = getOne(blacklist, tags);
+              imageDescription = `**BLACKLISTED RESULT** - Link Contains: ${blacklistMatch} | **Link:** [Click Here](http://gelbooru.com/index.php?page=post&s=view&id=${id})`;
             }
           }
 

--- a/src/commands/lewd/konachan.js
+++ b/src/commands/lewd/konachan.js
@@ -31,6 +31,10 @@ function findOne(haystack, arr) {
   return arr.some(v => haystack.includes(v));
 }
 
+function getOne(haystack, arr) {
+  return arr.find(v => haystack.includes(v));
+}
+
 function tags(client, evt, suffix) {
   return getBlackListRemove(evt.message.channel_id).then(removeValue => {
     let channelTest = evt.message.channel.nsfw;
@@ -109,7 +113,8 @@ function tags(client, evt, suffix) {
                 return;
               }
               fileurl = null;
-              imageDescription = `**BLACKLISTED RESULT** | **Link:** [Click Here](http://konachan.com/post/show/${id})`;
+              let blacklistMatch = getOne(blacklist, tags);
+              imageDescription = `**BLACKLISTED RESULT** - Link Contains: ${blacklistMatch} | **Link:** [Click Here](http://konachan.com/post/show/${id})`;
             }
           }
 

--- a/src/commands/lewd/rule34.js
+++ b/src/commands/lewd/rule34.js
@@ -31,6 +31,10 @@ function findOne(haystack, arr) {
   return arr.some(v => haystack.includes(v));
 }
 
+function getOne(haystack, arr) {
+  return arr.find(v => haystack.includes(v));
+}
+
 function tags(client, evt, suffix) {
   return getBlackListRemove(evt.message.channel_id).then(removeValue => {
     let channelTest = evt.message.channel.nsfw;
@@ -111,7 +115,8 @@ function tags(client, evt, suffix) {
                 return;
               }
               fileurl = null;
-              imageDescription = `**BLACKLISTED RESULT** | **Link:** [Click Here](http://rule34.xxx/index.php?page=post&s=view&id=${id})`;
+              let blacklistMatch = getOne(blacklist, tags);
+              imageDescription = `**BLACKLISTED RESULT** - Link Contains: ${blacklistMatch} | **Link:** [Click Here](http://rule34.xxx/index.php?page=post&s=view&id=${id})`;
             }
           }
 

--- a/src/commands/lewd/yandere.js
+++ b/src/commands/lewd/yandere.js
@@ -31,6 +31,10 @@ function findOne(haystack, arr) {
   return arr.some(v => haystack.includes(v));
 }
 
+function getOne(haystack, arr) {
+  return arr.find(v => haystack.includes(v));
+}
+
 function tags(client, evt, suffix) {
   return getBlackListRemove(evt.message.channel_id).then(removeValue => {
     let channelTest = evt.message.channel.nsfw;
@@ -108,7 +112,8 @@ function tags(client, evt, suffix) {
                 return;
               }
               file = null;
-              imageDescription = `**BLACKLISTED RESULT** | **Link:** [Click Here](https://yande.re/post/show/${id})`;
+              let blacklistMatch = getOne(blacklist, tags);
+              imageDescription = `**BLACKLISTED RESULT** - Link Contains: ${blacklistMatch} | **Link:** [Click Here](https://yande.re/post/show/${id})`;
             }
           }
 


### PR DESCRIPTION
In some cases, people are OK with some blacklisted tags, but not with others. This change will allow users to see a blacklisted tag that is on the result before deciding if they want to click the link, leading to fewer permanent mental scars.

Ideally, FurBot would find all matching tags between the blacklist and result and print the list in the message, but I'm still unfamiliar with JavaScript and having just one tag should be good enough for a heads-up.