### PR TITLE
4.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+<a name="4.4.3" />
+
+# 4.4.3 (September 29th, 2018)
+
+### Features
+- [NEW] `birb` command for posting feathery friendbs.
+
+### Bug Fixes
+- [FIX] Help documentation for `actioninfo` was not updated, but is now.
+- [FIX] Help documentation for `nuzzle` and `poke` was not present so didn't even show on help command, but is now.
+- [FIX] `info` command now uses bot avatar instead of static URL.
+
+
 <a name="4.4.2" />
 
 # 4.4.2 (September 25th, 2018)

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -224,7 +224,7 @@
   "bite": "Give user(s) a little monch",
   "lick": "Give user(s) a licking, mlem!",
   "spank": "Give user(s) a spanking. They probably deserve it.",
-  "actions": "Check statistics on how many actions you have received",
+  "actioninfo": "Check statistics on how many actions you have received",
   "ban": "Ban a member from your server",
   "kick": "Kick a member from your server",
   "softban": "Ban + Unban a member from your server (useful for clearing messages)"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "furbot",
-  "version": "4.4.2",
+  "version": "4.4.3",
   "description": "A furry bot for Discord",
   "main": "index.js",
   "dependencies": {
@@ -58,6 +58,7 @@
     "url-unshort": "^4.0.0",
     "wikijs": "^3.0.5",
     "wolfram-alpha": "^0.6.0",
+    "xml2json-light": "^1.0.6",
     "youtube-node": "^1.3.0"
   },
   "devDependencies": {

--- a/src/commands/actions/stats.js
+++ b/src/commands/actions/stats.js
@@ -34,9 +34,11 @@ function userStatistics(client, evt, suffix) {
 }
 
 export default {
-  actioninfo: userStatistics
+  actioninfo: userStatistics,
+  actionstats: userStatistics,
+  actinf: userStatistics
 };
 
 export const help = {
-  actions: { parameters: '@User' }
+  actioninfo: { parameters: '@User' }
 };

--- a/src/commands/fun/animals.js
+++ b/src/commands/fun/animals.js
@@ -29,6 +29,32 @@ function axolotl(client, evt, suffix) {
     .then(R.join('\n'));
 }
 
+function birb(client, evt, suffix) {
+  let count = 1;
+  if (suffix && suffix.split(' ')[0] === 'bomb') {
+    count = Number(suffix.split(' ')[1]) || 5;
+    if (count > 15) count = 15;
+    if (count < 0) count = 5;
+  }
+
+  const options = {
+    url: 'https://random.birb.pw/tweet/',
+    json: true
+  };
+
+  return Promise.resolve(R.repeat('dog', count))
+    .map(() => {
+      return request(options)
+        .then(req => {
+          let result = 'https://random.birb.pw/img/';
+          result += req.body;
+          return result;
+        })
+        .then(encodeURI);
+    })
+    .then(R.join('\n'));
+}
+
 function bun(client, evt, suffix) {
   let count = 1;
   if (suffix && suffix.split(' ')[0] === 'bomb') {
@@ -186,6 +212,7 @@ function animals(client, evt, suffix, lang) {
   suffix = split_suffix.join(' ');
 
   if (cmd === 'axolotl') return axolotl(client, evt, suffix);
+  if (cmd === 'birb') return bird(client, evt, suffix);
   if (cmd === 'bun') return bun(client, evt, suffix);
   if (cmd === 'cat') return cat(client, evt, suffix);
   if (cmd === 'dog') return dog(client, evt, suffix);
@@ -202,6 +229,9 @@ export default {
   axolotl,
   axlotl: axolotl,
   axo: axolotl,
+  birb,
+  bird: birb,
+  chirpyboi: birb,
   bun,
   bunny: bun,
   rabbit: bun,

--- a/src/commands/info/info.js
+++ b/src/commands/info/info.js
@@ -12,6 +12,7 @@ function botinfo(client, evt, suffix, lang, json) {
   const server_count = {guilds: client.Guilds.length, channels: client.Channels.length, users: client.Users.length};
   const client_id = nconf.get('CLIENT_ID');
   const bot_version = package_file.version;
+  const bot_avatar = client.User.avatar;
 
   if (argv.shardmode && !isNaN(argv.shardid) && !isNaN(argv.shardcount) && !json) {
     return getShardsCmdResults('servers')
@@ -27,7 +28,7 @@ function botinfo(client, evt, suffix, lang, json) {
           color: 2455143,
           author: {
             name: `FurBot Info`,
-            icon_url: 'https://cdn.discordapp.com/avatars/174186616422662144/e6b8c266186a60f6b947d1635c09459e.jpg' // eslint-disable-line camelcase
+            icon_url: bot_avatar // eslint-disable-line camelcase
           },
           description: `Hey there! These are my stats, to see all of my commands use \`${nconf.get('PREFIX')}help\``,
           fields: [


### PR DESCRIPTION
# 4.4.3 (September 29th, 2018)

### Features
- [NEW] `birb` command for posting feathery friendbs.

### Bug Fixes
- [FIX] Help documentation for `actioninfo` was not updated, but is now.
- [FIX] Help documentation for `nuzzle` and `poke` was not present so didn't even show on help command, but is now.
- [FIX] `info` command now uses bot avatar instead of static URL.