### PR TITLE
4.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+<a name="4.4.5" />
+
+# 4.4.5 (February 25th, 2019)
+
+### Features
+- [NEW] `blacklist strict` will now remove blacklisted results completely and, if possible, add a non blacklisted result.
+So for example, you will no longer get 3 images if you searched for 5 but 2 were blacklisted. The bot will now try to get
+you 5 images all the time, unless the results page only contained 5 (or less) images to begin with.
+
+- [NEW] `cub`, `loli` and `shota` are now blacklisted by default since these artworks are not allowed under discord ToS.
+You do not need to add or remove them from your own blacklists, these are hardcoded in.
+
+### Bug Fixes
+- [FIX] Removed the possibility of finding duplicate images in the image results for the lewd commands.
+- [FIX] Fixed a long standing bug where if the artist name contained a number the lewd commands would not work properly.
+- [FIX] Fixed some lewd commands (konachan, danbooru) that were no longer working, they are all working now.
+- [FIX] The say command no longer removes markdown (you can't use @ still)
+- 
+
+### Notes
+- [REMOVED] The christmas commands. It's february alright, get over it!
+
+
 <a name="4.4.4" />
 
 # 4.4.4 (December 20th, 2018)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,14 @@
 So for example, you will no longer get 3 images if you searched for 5 but 2 were blacklisted. The bot will now try to get
 you 5 images all the time, unless the results page only contained 5 (or less) images to begin with.
 
-- [NEW] `cub`, `loli` and `shota` are now blacklisted by default since these artworks are not allowed under discord ToS.
+- [NEW] `cub`, `loli`, `young` and `shota` are now blacklisted by default since these artworks are not allowed under discord ToS.
 You do not need to add or remove them from your own blacklists, these are hardcoded in.
 
 ### Bug Fixes
 - [FIX] Removed the possibility of finding duplicate images in the image results for the lewd commands.
 - [FIX] Fixed a long standing bug where if the artist name contained a number the lewd commands would not work properly.
-- [FIX] Fixed some lewd commands (konachan, danbooru) that were no longer working, they are all working now.
+- [FIX] Fixed some lewd commands (konachan, danbooru, gelbooru) that were no longer working, they are all working now.
 - [FIX] The say command no longer removes markdown (you can't use @ still)
-- 
 
 ### Notes
 - [REMOVED] The christmas commands. It's february alright, get over it!

--- a/src/commands/fun/dadjoke.js
+++ b/src/commands/fun/dadjoke.js
@@ -8,7 +8,7 @@ function _makeRequest(options) {
   let default_options = {
     headers: {
       'Content-Type': 'application/json',
-      'User-Agent': 'FurBot/1.0 (https://github.com/PhunStyle/FurBot)'
+      'User-Agent': 'PhunStyle/FurBot @ GitHub'
     },
     json: true
   };

--- a/src/commands/fun/say.js
+++ b/src/commands/fun/say.js
@@ -1,13 +1,21 @@
-import { cleanName } from '../../helpers';
+import { cleanSay } from '../../helpers';
 
 function say(client, evt, suffix) {
   if (!suffix) return;
-  suffix = cleanName(suffix);
+  suffix = cleanSay(suffix);
+  return evt.message.channel.sendMessage(suffix);
+}
+
+function delsay(client, evt, suffix) {
+  if (!suffix) return;
+  suffix = cleanSay(suffix);
+  evt.message.delete();
   return evt.message.channel.sendMessage(suffix);
 }
 
 export default {
-  say
+  say,
+  delsay
 };
 
 export const help = {

--- a/src/commands/lewd/danbooru.js
+++ b/src/commands/lewd/danbooru.js
@@ -55,8 +55,8 @@ function tags(client, evt, suffix) {
       }
       let query;
       let lastTag = array[array.length - 1];
-      console.log('lastTag: ' + lastTag);
-      console.log('lastTag isNum: ' + isNumeric(lastTag));
+      //console.log('lastTag: ' + lastTag);
+      //console.log('lastTag isNum: ' + isNumeric(lastTag));
       let count = 1;
       if (suffix && isNumeric(lastTag)) {
         count = lastTag;
@@ -69,7 +69,7 @@ function tags(client, evt, suffix) {
         query = suffix.toLowerCase().replace('tags ', '');
       }
 
-      console.log('query: ' + query);
+      //console.log('query: ' + query);
 
       if (query === '') return Promise.resolve(`\u26A0  |  No tags were supplied`);
       let checkLength = query.split(' ');
@@ -78,7 +78,7 @@ function tags(client, evt, suffix) {
       const options = {
         url: `http://danbooru.donmai.us/posts.json?tags=${query}&random=true`,
         qs: {
-          limit: 20
+          limit: 100
         }
       };
 
@@ -92,25 +92,33 @@ function tags(client, evt, suffix) {
            return Promise.resolve(`\u26A0  |  No results for: \`${query}\``);
         }
         if (body) {
-          console.log('body: ' + body);
-          console.log('bodylength: ' + body.length);
+          //console.log('Body Before BL: ' + body);
+          //console.log('BodyLength Before BL: ' + body.length);
           let i;
           for (i = body.length - 1; i >= 0; i--) {
-            // Apply blacklisting
-            if (value) {
-              let tags = body[i].tag_string.split(' ');
-              if (findOne(blacklist, tags) || body[i].tag_string.includes('cub') || body[i].tag_string.includes('shota') || body[i].tag_string.includes('loli')) {
-                if (removeValue === 'true') {
-                  body.splice(i,1);
-                }
-              }
+            if (body[i].tag_string.includes('cub') || body[i].tag_string.includes('shota') || body[i].tag_string.includes('loli') || body[i].tag_string.includes('young')) {
+                body.splice(i,1);
             }
           }
+          //console.log('Body After Default BL: ' + body);
+          //console.log('BodyLength After Default BL: ' + body.length);
+          // Apply blacklisting strictness
+          if (value && removeValue === 'true') {
+            for (i = body.length - 1; i >= 0; i--) {
+              let tags = body[i].tag_string.split(' ');
+              if (findOne(blacklist, tags)) {
+                  body.splice(i,1);
+              }
+            }
+            //console.log('Body After Custom BL: ' + body);
+            //console.log('BodyLength After Custom BL: ' + body.length);
+          }
         }
-        console.log('body2: ' + body);
-        console.log('bodylength2: ' + body.length);
         if (count > body.length) {
           count = body.length;
+        }
+        if (!body || typeof body[0] === 'undefined' || typeof body === 'undefined' || body.length === 0) {
+           return Promise.resolve(`\u26A0  |  No results for: \`${query}\``);
         }
         return Promise.resolve(R.repeat('tags', count))
         .map(() => {
@@ -149,13 +157,10 @@ function tags(client, evt, suffix) {
             url: 'http://danbooru.donmai.us/posts/' + id,
             description: imageDescription,
             image: { url: fileurl },
-            footer: { icon_url: 'http://i.imgur.com/BrMcA8z.png', text: 'danbooru' }
+            footer: { icon_url: 'http://i.imgur.com/BrMcA8z.png', text: 'danbooru · ' + currentPosition + '/' + count }
           };
 
           body.splice(randomid,1);
-
-          console.log('body3: ' + body);
-          console.log('bodylength3: ' + body.length);
 
           return evt.message.channel.sendMessage('', false, embed);
         });

--- a/src/commands/lewd/danbooru.js
+++ b/src/commands/lewd/danbooru.js
@@ -12,7 +12,7 @@ function _makeRequest(options) {
   let default_options = {
     json: true,
     headers: {
-      'User-Agent': 'FurBot/1.0 (Phun @ e621)'
+      'User-Agent': 'PhunStyle/FurBot @ GitHub'
     }
   };
 
@@ -35,6 +35,10 @@ function getOne(haystack, arr) {
   return arr.find(v => haystack.includes(v));
 }
 
+function isNumeric(num){
+  return !isNaN(num);
+}
+
 function tags(client, evt, suffix) {
   return getBlackListRemove(evt.message.channel_id).then(removeValue => {
     let channelTest = evt.message.channel.nsfw;
@@ -50,9 +54,11 @@ function tags(client, evt, suffix) {
         }
       }
       let query;
-      let lastTag = Number.parseInt(array[array.length - 1], 10);
+      let lastTag = array[array.length - 1];
+      console.log('lastTag: ' + lastTag);
+      console.log('lastTag isNum: ' + isNumeric(lastTag));
       let count = 1;
-      if (suffix && Number.isInteger(lastTag)) {
+      if (suffix && isNumeric(lastTag)) {
         count = lastTag;
         if (count > 5) count = 5;
         if (count < 0) count = 1;
@@ -62,6 +68,8 @@ function tags(client, evt, suffix) {
       } else {
         query = suffix.toLowerCase().replace('tags ', '');
       }
+
+      console.log('query: ' + query);
 
       if (query === '') return Promise.resolve(`\u26A0  |  No tags were supplied`);
       let checkLength = query.split(' ');
@@ -83,8 +91,30 @@ function tags(client, evt, suffix) {
         if (!body || typeof body[0] === 'undefined' || typeof body === 'undefined' || body.length === 0) {
            return Promise.resolve(`\u26A0  |  No results for: \`${query}\``);
         }
+        if (body) {
+          console.log('body: ' + body);
+          console.log('bodylength: ' + body.length);
+          let i;
+          for (i = body.length - 1; i >= 0; i--) {
+            // Apply blacklisting
+            if (value) {
+              let tags = body[i].tag_string.split(' ');
+              if (findOne(blacklist, tags) || body[i].tag_string.includes('cub') || body[i].tag_string.includes('shota') || body[i].tag_string.includes('loli')) {
+                if (removeValue === 'true') {
+                  body.splice(i,1);
+                }
+              }
+            }
+          }
+        }
+        console.log('body2: ' + body);
+        console.log('bodylength2: ' + body.length);
+        if (count > body.length) {
+          count = body.length;
+        }
         return Promise.resolve(R.repeat('tags', count))
         .map(() => {
+          if (body.length === 0) return;
           // Do some math
           let randomid = Math.floor(Math.random() * body.length);
           currentPosition++;
@@ -93,28 +123,20 @@ function tags(client, evt, suffix) {
           let file = body[randomid].file_url;
           let fileurl = `${file}`;
           let score = body[randomid].score;
-          let imageDescription = `**Score:** ${score} | **Link:** [Click Here](http://danbooru.donmai.us/posts/${id})`;
+          let imageDescription = `**Score:** ${score} | [**Link**](http://danbooru.donmai.us/posts/${id})`;
           if (file) {
             if (file.endsWith('webm') || file.endsWith('swf')) {
-              imageDescription = `**Score:** ${score} | **Link:** [Click Here](http://danbooru.donmai.us/posts/${id})\n*This file (webm/swf) cannot be previewed or embedded.*`;
+              imageDescription = `**Score:** ${score} | [**Link**](http://danbooru.donmai.us/posts/${id})\n*This file (webm/swf) cannot be previewed or embedded.*`;
             }
           }
 
           // Apply blacklisting
           if (value) {
-            let tags = body[randomid].tags.split(' ');
+            let tags = body[randomid].tag_string.split(' ');
             if (findOne(blacklist, tags)) {
-              if (removeValue === 'true') {
-                blacklistHits++;
-                if (blacklistHits > 0 && currentPosition === count) {
-                  return evt.message.channel.sendMessage('', false, {color: 4437377, description: `<:greenTick:405749911037018125> Skipped \`${blacklistHits}\` blacklisted results.`})
-                  .then(message => { setTimeout(() => { message.delete(); }, 5000); });
-                }
-                return;
-              }
               fileurl = null;
               let blacklistMatch = getOne(blacklist, tags);
-              imageDescription = `**BLACKLISTED** - Matched: \`${blacklistMatch}\` | **Link:** [Click Here](http://danbooru.donmai.us/posts/${id})`;
+              imageDescription = `**BLACKLISTED** - Matched: \`${blacklistMatch}\` | [**Link**](https://e621.net/post/show/${id})`;
             }
           }
 
@@ -129,6 +151,12 @@ function tags(client, evt, suffix) {
             image: { url: fileurl },
             footer: { icon_url: 'http://i.imgur.com/BrMcA8z.png', text: 'danbooru' }
           };
+
+          body.splice(randomid,1);
+
+          console.log('body3: ' + body);
+          console.log('bodylength3: ' + body.length);
+
           return evt.message.channel.sendMessage('', false, embed);
         });
       });
@@ -139,7 +167,6 @@ function tags(client, evt, suffix) {
 export default {
   db: (client, evt, suffix, lang) => {
     const command = suffix.toLowerCase().split(' ')[0];
-    // if (command === 'latest') return latest(client, evt, suffix);
     if (command === 'tags') return tags(client, evt, suffix);
     if (command !== 'tags' || command !== 'latest') return tags(client, evt, suffix);
   }

--- a/src/commands/lewd/derpibooru.js
+++ b/src/commands/lewd/derpibooru.js
@@ -13,7 +13,7 @@ function _makeRequest(options) {
   let default_options = {
     json: true,
     headers: {
-      'User-Agent': 'FurBot/1.0 (Phun @ e621)'
+      'User-Agent': 'PhunStyle/FurBot @ GitHub'
     }
   };
 
@@ -36,6 +36,10 @@ function getOne(haystack, arr) {
   return arr.find(v => haystack.includes(v));
 }
 
+function isNumeric(num){
+  return !isNaN(num);
+}
+
 function tags(client, evt, suffix) {
   return getBlackListRemove(evt.message.channel_id).then(removeValue => {
     let channelTest = evt.message.channel.nsfw;
@@ -51,9 +55,11 @@ function tags(client, evt, suffix) {
         }
       }
       let query;
-      let lastTag = Number.parseInt(array[array.length - 1], 10);
+      let lastTag = array[array.length - 1];
+      console.log('lastTag: ' + lastTag);
+      console.log('lastTag isNum: ' + isNumeric(lastTag));
       let count = 1;
-      if (suffix && Number.isInteger(lastTag)) {
+      if (suffix && isNumeric(lastTag)) {
         count = lastTag;
         if (count > 5) count = 5;
         if (count < 0) count = 1;
@@ -65,6 +71,8 @@ function tags(client, evt, suffix) {
       }
       query = query.replace(/ /gi, ',');
       query = query.replace(/_/gi, '+');
+
+      console.log('query: ' + query);
 
       if (query === '') return Promise.resolve(`\u26A0  |  No tags were supplied`);
       let checkLength = query.split(' ');
@@ -98,6 +106,28 @@ function tags(client, evt, suffix) {
           if (!body || typeof body.search[0] === 'undefined' || typeof body === 'undefined' || body.search.length === 0) {
              return Promise.resolve(`\u26A0  |  No results for: \`${query}\``);
           }
+          if (body) {
+            console.log('body: ' + body);
+            console.log('bodylength: ' + body.search.length);
+            let i;
+            for (i = body.search.length - 1; i >= 0; i--) {
+              // Apply blacklisting
+              if (value) {
+                let tags = body.search[i].tags.split(' ');
+                if (findOne(blacklist, tags) || body.search[i].tags.includes('cub') || body.search[i].tags.includes('shota') || body.search[i].tags.includes('loli')) {
+                  if (removeValue === 'true') {
+                    body.search.splice(i,1);
+                  }
+                }
+              }
+            }
+          }
+          console.log('body2: ' + body);
+          console.log('bodylength2: ' + body.search.length);
+          if (count > body.search.length) {
+            count = body.search.length;
+          }
+          if (body.search.length === 0) return;
           // Do some math
           let randomid = Math.floor(Math.random() * body.search.length);
           currentPosition++;
@@ -108,10 +138,10 @@ function tags(client, evt, suffix) {
           let height = body.search[randomid].height;
           let width = body.search[randomid].width;
           let score = body.search[randomid].score;
-          let imageDescription = `**Score:** ${score} | **Resolution: ** ${width} x ${height} | **Link:** [Click Here](https://derpibooru.org/${id})`;
+          let imageDescription = `**Score:** ${score} | **Resolution: ** ${width} x ${height} | [**Link**](https://derpibooru.org/${id})`;
           if (file) {
             if (file.endsWith('webm') || file.endsWith('swf')) {
-              imageDescription = `**Score:** ${score} | **Link:** [Click Here](https://derpibooru.org/${id})\n*This file (webm/swf) cannot be previewed or embedded.*`;
+              imageDescription = `**Score:** ${score} | [**Link**](https://derpibooru.org/${id})\n*This file (webm/swf) cannot be previewed or embedded.*`;
             }
           }
 
@@ -119,17 +149,9 @@ function tags(client, evt, suffix) {
           if (value) {
             let tags = body.search[randomid].tags.split(', ');
             if (findOne(blacklist, tags)) {
-              if (removeValue === 'true') {
-                blacklistHits++;
-                if (blacklistHits > 0 && currentPosition === count) {
-                  return evt.message.channel.sendMessage('', false, {color: 4437377, description: `<:greenTick:405749911037018125> Skipped \`${blacklistHits}\` blacklisted results.`})
-                  .then(message => { setTimeout(() => { message.delete(); }, 5000); });
-                }
-                return;
-              }
               fileurl = null;
               let blacklistMatch = getOne(blacklist, tags);
-              imageDescription = `**BLACKLISTED** - Matched: \`${blacklistMatch}\` | **Link:** [Click Here](https://derpibooru.org/${id})`;
+              imageDescription = `**BLACKLISTED** - Matched: \`${blacklistMatch}\` | [**Link**](https://e621.net/post/show/${id})`;
             }
           }
 
@@ -144,6 +166,12 @@ function tags(client, evt, suffix) {
             image: { url: fileurl },
             footer: { icon_url: 'http://i.imgur.com/qeJd6ST.png', text: 'derpibooru' }
           };
+
+          console.log('body3: ' + body);
+          console.log('bodylength3: ' + body.search.length);
+
+          body.search.splice(randomid,1);
+
           return evt.message.channel.sendMessage('', false, embed);
         });
       });

--- a/src/commands/lewd/derpibooru.js
+++ b/src/commands/lewd/derpibooru.js
@@ -56,8 +56,8 @@ function tags(client, evt, suffix) {
       }
       let query;
       let lastTag = array[array.length - 1];
-      console.log('lastTag: ' + lastTag);
-      console.log('lastTag isNum: ' + isNumeric(lastTag));
+      //console.log('lastTag: ' + lastTag);
+      //console.log('lastTag isNum: ' + isNumeric(lastTag));
       let count = 1;
       if (suffix && isNumeric(lastTag)) {
         count = lastTag;
@@ -72,7 +72,7 @@ function tags(client, evt, suffix) {
       query = query.replace(/ /gi, ',');
       query = query.replace(/_/gi, '+');
 
-      console.log('query: ' + query);
+      //console.log('query: ' + query);
 
       if (query === '') return Promise.resolve(`\u26A0  |  No tags were supplied`);
       let checkLength = query.split(' ');
@@ -107,27 +107,34 @@ function tags(client, evt, suffix) {
              return Promise.resolve(`\u26A0  |  No results for: \`${query}\``);
           }
           if (body) {
-            console.log('body: ' + body);
-            console.log('bodylength: ' + body.search.length);
+            //console.log('Body Before BL: ' + body);
+            //console.log('BodyLength Before BL: ' + body.search.length);
             let i;
             for (i = body.search.length - 1; i >= 0; i--) {
-              // Apply blacklisting
-              if (value) {
-                let tags = body.search[i].tags.split(' ');
-                if (findOne(blacklist, tags) || body.search[i].tags.includes('cub') || body.search[i].tags.includes('shota') || body.search[i].tags.includes('loli')) {
-                  if (removeValue === 'true') {
-                    body.search.splice(i,1);
-                  }
-                }
+              if (body.search[i].tags.includes('cub') || body.search[i].tags.includes('shota') || body.search[i].tags.includes('loli') || body.search[i].tags.includes('foalcon')) {
+                  body.search.splice(i,1);
               }
             }
+            //console.log('Body After Default BL: ' + body);
+            //console.log('BodyLength After Default BL: ' + body.search.length);
+            // Apply blacklisting strictness
+            if (value && removeValue === 'true') {
+              for (i = body.search.length - 1; i >= 0; i--) {
+                let tags = body.search[i].tags.split(' ');
+                if (findOne(blacklist, tags)) {
+                    body.search.splice(i,1);
+                }
+              }
+              //console.log('Body After Custom BL: ' + body);
+              //console.log('BodyLength After Custom BL: ' + body.search.length);
+            }
           }
-          console.log('body2: ' + body);
-          console.log('bodylength2: ' + body.search.length);
           if (count > body.search.length) {
             count = body.search.length;
           }
-          if (body.search.length === 0) return;
+          if (!body || typeof body.search[0] === 'undefined' || typeof body === 'undefined' || body.search.length === 0) {
+             return Promise.resolve(`\u26A0  |  No results for: \`${query}\``);
+          }
           // Do some math
           let randomid = Math.floor(Math.random() * body.search.length);
           currentPosition++;
@@ -164,11 +171,8 @@ function tags(client, evt, suffix) {
             url: 'https://derpibooru.org/' + id,
             description: imageDescription,
             image: { url: fileurl },
-            footer: { icon_url: 'http://i.imgur.com/qeJd6ST.png', text: 'derpibooru' }
+            footer: { icon_url: 'http://i.imgur.com/qeJd6ST.png', text: 'derpibooru · ' + currentPosition + '/' + count }
           };
-
-          console.log('body3: ' + body);
-          console.log('bodylength3: ' + body.search.length);
 
           body.search.splice(randomid,1);
 
@@ -182,7 +186,6 @@ function tags(client, evt, suffix) {
 export default {
   dp: (client, evt, suffix, lang) => {
     const command = suffix.toLowerCase().split(' ')[0];
-    // if (command === 'latest') return latest(client, evt, suffix);
     if (command === 'tags') return tags(client, evt, suffix);
     if (command !== 'tags' || command !== 'latest') return tags(client, evt, suffix);
   }

--- a/src/commands/lewd/e926.js
+++ b/src/commands/lewd/e926.js
@@ -52,8 +52,8 @@ function tags(client, evt, suffix) {
       }
       let query;
       let lastTag = array[array.length - 1];
-      console.log('lastTag: ' + lastTag);
-      console.log('lastTag isNum: ' + isNumeric(lastTag));
+      //console.log('lastTag: ' + lastTag);
+      //console.log('lastTag isNum: ' + isNumeric(lastTag));
       let count = 1;
       if (suffix && isNumeric(lastTag)) {
         count = lastTag;
@@ -66,7 +66,7 @@ function tags(client, evt, suffix) {
         query = suffix.toLowerCase().replace('tags ', '');
       }
 
-      console.log('query: ' + query);
+      //console.log('query: ' + query);
 
       if (query === '') return Promise.resolve(`\u26A0  |  No tags were supplied`);
       let checkLength = query.split(' ');
@@ -89,25 +89,26 @@ function tags(client, evt, suffix) {
            return Promise.resolve(`\u26A0  |  No results for: \`${query}\``);
         }
         if (body) {
-          console.log('body: ' + body);
-          console.log('bodylength: ' + body.length);
+          //console.log('Body Before BL: ' + body);
+          //console.log('BodyLength Before BL: ' + body.length);
           let i;
-          for (i = body.length - 1; i >= 0; i--) {
-            // Apply blacklisting
-            if (value) {
+          // Apply blacklisting strictness
+          if (value && removeValue === 'true') {
+            for (i = body.length - 1; i >= 0; i--) {
               let tags = body[i].tags.split(' ');
-              if (findOne(blacklist, tags) || body[i].tags.includes('cub') || body[i].tags.includes('shota') || body[i].tags.includes('loli')) {
-                if (removeValue === 'true') {
+              if (findOne(blacklist, tags)) {
                   body.splice(i,1);
-                }
               }
             }
+            //console.log('Body After Custom BL: ' + body);
+            //console.log('BodyLength After Custom BL: ' + body.length);
           }
         }
-        console.log('body2: ' + body);
-        console.log('bodylength2: ' + body.length);
         if (count > body.length) {
           count = body.length;
+        }
+        if (!body || typeof body[0] === 'undefined' || typeof body === 'undefined' || body.length === 0) {
+           return Promise.resolve(`\u26A0  |  No results for: \`${query}\``);
         }
         return Promise.resolve(R.repeat('tags', count))
         .map(() => {
@@ -147,13 +148,10 @@ function tags(client, evt, suffix) {
             url: 'https://e926.net/post/show/' + id,
             description: imageDescription,
             image: { url: file },
-            footer: { icon_url: 'http://i.imgur.com/RrHrSOi.png', text: 'e926' }
+            footer: { icon_url: 'http://i.imgur.com/RrHrSOi.png', text: 'e926 · ' + currentPosition + '/' + count }
           };
 
           body.splice(randomid,1);
-
-          console.log('body3: ' + body);
-          console.log('bodylength3: ' + body.length);
 
           return evt.message.channel.sendMessage('', false, embed);
         });

--- a/src/commands/lewd/e926.js
+++ b/src/commands/lewd/e926.js
@@ -12,7 +12,7 @@ function _makeRequest(options) {
   let default_options = {
     json: true,
     headers: {
-      'User-Agent': 'FurBot/1.0 (Phun @ e926)'
+      'User-Agent': 'PhunStyle/FurBot @ GitHub'
     }
   };
 
@@ -35,6 +35,10 @@ function getOne(haystack, arr) {
   return arr.find(v => haystack.includes(v));
 }
 
+function isNumeric(num){
+  return !isNaN(num);
+}
+
 function tags(client, evt, suffix) {
   return getBlackListRemove(evt.message.channel_id).then(removeValue => {
     return getBlackListChannel(evt.message.channel_id).then(value => {
@@ -47,9 +51,11 @@ function tags(client, evt, suffix) {
         }
       }
       let query;
-      let lastTag = Number.parseInt(array[array.length - 1], 10);
+      let lastTag = array[array.length - 1];
+      console.log('lastTag: ' + lastTag);
+      console.log('lastTag isNum: ' + isNumeric(lastTag));
       let count = 1;
-      if (suffix && Number.isInteger(lastTag)) {
+      if (suffix && isNumeric(lastTag)) {
         count = lastTag;
         if (count > 5) count = 5;
         if (count < 0) count = 1;
@@ -59,6 +65,8 @@ function tags(client, evt, suffix) {
       } else {
         query = suffix.toLowerCase().replace('tags ', '');
       }
+
+      console.log('query: ' + query);
 
       if (query === '') return Promise.resolve(`\u26A0  |  No tags were supplied`);
       let checkLength = query.split(' ');
@@ -80,8 +88,30 @@ function tags(client, evt, suffix) {
         if (!body || typeof body[0] === 'undefined' || typeof body === 'undefined' || body.length === 0) {
            return Promise.resolve(`\u26A0  |  No results for: \`${query}\``);
         }
+        if (body) {
+          console.log('body: ' + body);
+          console.log('bodylength: ' + body.length);
+          let i;
+          for (i = body.length - 1; i >= 0; i--) {
+            // Apply blacklisting
+            if (value) {
+              let tags = body[i].tags.split(' ');
+              if (findOne(blacklist, tags) || body[i].tags.includes('cub') || body[i].tags.includes('shota') || body[i].tags.includes('loli')) {
+                if (removeValue === 'true') {
+                  body.splice(i,1);
+                }
+              }
+            }
+          }
+        }
+        console.log('body2: ' + body);
+        console.log('bodylength2: ' + body.length);
+        if (count > body.length) {
+          count = body.length;
+        }
         return Promise.resolve(R.repeat('tags', count))
         .map(() => {
+          if (body.length === 0) return;
           // Do some math
           let randomid = Math.floor(Math.random() * body.length);
           currentPosition++;
@@ -91,10 +121,10 @@ function tags(client, evt, suffix) {
           let height = body[randomid].height;
           let width = body[randomid].width;
           let score = body[randomid].score;
-          let imageDescription = `**Score:** ${score} | **Resolution: ** ${width} x ${height} | **Link:** [Click Here](https://e926.net/post/show/${id})`;
+          let imageDescription = `**Score:** ${score} | **Resolution: ** ${width} x ${height} | [**Link**](https://e926.net/post/show/${id})`;
           if (file) {
             if (file.endsWith('webm') || file.endsWith('swf')) {
-              imageDescription = `**Score:** ${score} | **Link:** [Click Here](https://e926.net/post/show/${id})\n*This file (webm/swf) cannot be previewed or embedded.*`;
+              imageDescription = `**Score:** ${score} | [**Link**](https://e926.net/post/show/${id})\n*This file (webm/swf) cannot be previewed or embedded.*`;
             }
           }
 
@@ -102,17 +132,9 @@ function tags(client, evt, suffix) {
           if (value) {
             let tags = body[randomid].tags.split(' ');
             if (findOne(blacklist, tags)) {
-              if (removeValue === 'true') {
-                blacklistHits++;
-                if (blacklistHits > 0 && currentPosition === count) {
-                  return evt.message.channel.sendMessage('', false, {color: 4437377, description: `<:greenTick:405749911037018125> Skipped \`${blacklistHits}\` blacklisted results.`})
-                  .then(message => { setTimeout(() => { message.delete(); }, 5000); });
-                }
-                return;
-              }
               file = null;
               let blacklistMatch = getOne(blacklist, tags);
-              imageDescription = `**BLACKLISTED** - Matched: \`${blacklistMatch}\` | **Link:** [Click Here](https://e926.net/post/show/${id})`;
+              imageDescription = `**BLACKLISTED** - Matched: \`${blacklistMatch}\` | [**Link**](https://e621.net/post/show/${id})`;
             }
           }
 
@@ -127,6 +149,12 @@ function tags(client, evt, suffix) {
             image: { url: file },
             footer: { icon_url: 'http://i.imgur.com/RrHrSOi.png', text: 'e926' }
           };
+
+          body.splice(randomid,1);
+
+          console.log('body3: ' + body);
+          console.log('bodylength3: ' + body.length);
+
           return evt.message.channel.sendMessage('', false, embed);
         });
       });
@@ -137,7 +165,6 @@ function tags(client, evt, suffix) {
 export default {
   e9: (client, evt, suffix, lang) => {
     const command = suffix.toLowerCase().split(' ')[0];
-    // if (command === 'latest') return latest(client, evt, suffix);
     if (command === 'tags') return tags(client, evt, suffix);
     if (command !== 'tags' || command !== 'latest') return tags(client, evt, suffix);
   }

--- a/src/commands/lewd/furrybooru.js
+++ b/src/commands/lewd/furrybooru.js
@@ -12,7 +12,7 @@ function _makeRequest(options) {
   let default_options = {
     json: true,
     headers: {
-      'User-Agent': 'FurBot/1.0 (Phun @ e621)'
+      'User-Agent': 'PhunStyle/FurBot @ GitHub'
     }
   };
 
@@ -33,6 +33,10 @@ function findOne(haystack, arr) {
 
 function getOne(haystack, arr) {
   return arr.find(v => haystack.includes(v));
+}
+
+function isNumeric(num){
+  return !isNaN(num);
 }
 
 function tags(client, evt, suffix) {
@@ -63,6 +67,8 @@ function tags(client, evt, suffix) {
         query = suffix.toLowerCase().replace('tags ', '');
       }
 
+      console.log('query: ' + query);
+
       if (query === '') return Promise.resolve(`\u26A0  |  No tags were supplied`);
       let checkLength = query.split(' ');
       if (checkLength.length > 6) return Promise.resolve(`\u26A0  |  You can only search up to 6 tags`);
@@ -84,8 +90,30 @@ function tags(client, evt, suffix) {
         if (!body || typeof body[0] === 'undefined' || typeof body === 'undefined' || body.length === 0) {
            return Promise.resolve(`\u26A0  |  No results for: \`${query}\``);
         }
+        if (body) {
+          console.log('body: ' + body);
+          console.log('bodylength: ' + body.length);
+          let i;
+          for (i = body.length - 1; i >= 0; i--) {
+            // Apply blacklisting
+            if (value) {
+              let tags = body[i].tags.split(' ');
+              if (findOne(blacklist, tags) || body[i].tags.includes('cub') || body[i].tags.includes('shota') || body[i].tags.includes('loli')) {
+                if (removeValue === 'true') {
+                  body.splice(i,1);
+                }
+              }
+            }
+          }
+        }
+        console.log('body2: ' + body);
+        console.log('bodylength2: ' + body.length);
+        if (count > body.length) {
+          count = body.length;
+        }
         return Promise.resolve(R.repeat('tags', count))
         .map(() => {
+          if (body.length === 0) return;
           // Do some math
           let randomid = Math.floor(Math.random() * body.length);
           currentPosition++;
@@ -97,10 +125,10 @@ function tags(client, evt, suffix) {
           let height = body[randomid].height;
           let width = body[randomid].width;
           let score = body[randomid].score;
-          let imageDescription = `**Score:** ${score} | **Resolution: ** ${width} x ${height} | **Link:** [Click Here](http://furry.booru.org/index.php?page=post&s=view&id=${id})`;
+          let imageDescription = `**Score:** ${score} | **Resolution: ** ${width} x ${height} | [**Link**](http://furry.booru.org/index.php?page=post&s=view&id=${id})`;
           if (file) {
             if (file.endsWith('webm') || file.endsWith('swf')) {
-              imageDescription = `**Score:** ${score} | **Link:** [Click Here](http://furry.booru.org/index.php?page=post&s=view&id=${id})\n*This file (webm/swf) cannot be previewed or embedded.*`;
+              imageDescription = `**Score:** ${score} | [**Link**](http://furry.booru.org/index.php?page=post&s=view&id=${id})\n*This file (webm/swf) cannot be previewed or embedded.*`;
             }
           }
 
@@ -108,17 +136,9 @@ function tags(client, evt, suffix) {
           if (value) {
             let tags = body[randomid].tags.split(' ');
             if (findOne(blacklist, tags)) {
-              if (removeValue === 'true') {
-                blacklistHits++;
-                if (blacklistHits > 0 && currentPosition === count) {
-                  return evt.message.channel.sendMessage('', false, {color: 4437377, description: `<:greenTick:405749911037018125> Skipped \`${blacklistHits}\` blacklisted results.`})
-                  .then(message => { setTimeout(() => { message.delete(); }, 5000); });
-                }
-                return;
-              }
               fileurl = null;
               let blacklistMatch = getOne(blacklist, tags);
-              imageDescription = `**BLACKLISTED** - Matched: \`${blacklistMatch}\` | **Link:** [Click Here](http://furry.booru.org/index.php?page=post&s=view&id=${id})`;
+              imageDescription = `**BLACKLISTED** - Matched: \`${blacklistMatch}\` | [**Link**](https://e621.net/post/show/${id})`;
             }
           }
 
@@ -133,6 +153,12 @@ function tags(client, evt, suffix) {
             image: { url: fileurl },
             footer: { icon_url: 'http://i.imgur.com/zrdxCfF.png', text: 'furrybooru' }
           };
+
+          body.splice(randomid,1);
+
+          console.log('body3: ' + body);
+          console.log('bodylength3: ' + body.length);
+
           return evt.message.channel.sendMessage('', false, embed);
         });
       });
@@ -143,7 +169,6 @@ function tags(client, evt, suffix) {
 export default {
   fb: (client, evt, suffix, lang) => {
     const command = suffix.toLowerCase().split(' ')[0];
-    // if (command === 'latest') return latest(client, evt, suffix);
     if (command === 'tags') return tags(client, evt, suffix);
     if (command !== 'tags' || command !== 'latest') return tags(client, evt, suffix);
   }

--- a/src/commands/lewd/furrybooru.js
+++ b/src/commands/lewd/furrybooru.js
@@ -54,9 +54,11 @@ function tags(client, evt, suffix) {
         }
       }
       let query;
-      let lastTag = Number.parseInt(array[array.length - 1], 10);
+      let lastTag = array[array.length - 1];
+      //console.log('lastTag: ' + lastTag);
+      //console.log('lastTag isNum: ' + isNumeric(lastTag));
       let count = 1;
-      if (suffix && Number.isInteger(lastTag)) {
+      if (suffix && isNumeric(lastTag)) {
         count = lastTag;
         if (count > 5) count = 5;
         if (count < 0) count = 1;
@@ -67,7 +69,7 @@ function tags(client, evt, suffix) {
         query = suffix.toLowerCase().replace('tags ', '');
       }
 
-      console.log('query: ' + query);
+      //console.log('query: ' + query);
 
       if (query === '') return Promise.resolve(`\u26A0  |  No tags were supplied`);
       let checkLength = query.split(' ');
@@ -91,25 +93,33 @@ function tags(client, evt, suffix) {
            return Promise.resolve(`\u26A0  |  No results for: \`${query}\``);
         }
         if (body) {
-          console.log('body: ' + body);
-          console.log('bodylength: ' + body.length);
+          //console.log('Body Before BL: ' + body);
+          //console.log('BodyLength Before BL: ' + body.length);
           let i;
           for (i = body.length - 1; i >= 0; i--) {
-            // Apply blacklisting
-            if (value) {
-              let tags = body[i].tags.split(' ');
-              if (findOne(blacklist, tags) || body[i].tags.includes('cub') || body[i].tags.includes('shota') || body[i].tags.includes('loli')) {
-                if (removeValue === 'true') {
-                  body.splice(i,1);
-                }
-              }
+            if (body[i].tags.includes('cub') || body[i].tags.includes('shota') || body[i].tags.includes('loli') || body[i].tags.includes('young')) {
+                body.splice(i,1);
             }
           }
+          //console.log('Body After Default BL: ' + body);
+          //console.log('BodyLength After Default BL: ' + body.length);
+          // Apply blacklisting strictness
+          if (value && removeValue === 'true') {
+            for (i = body.length - 1; i >= 0; i--) {
+              let tags = body[i].tags.split(' ');
+              if (findOne(blacklist, tags)) {
+                  body.splice(i,1);
+              }
+            }
+            //console.log('Body After Custom BL: ' + body);
+            //console.log('BodyLength After Custom BL: ' + body.length);
+          }
         }
-        console.log('body2: ' + body);
-        console.log('bodylength2: ' + body.length);
         if (count > body.length) {
           count = body.length;
+        }
+        if (!body || typeof body[0] === 'undefined' || typeof body === 'undefined' || body.length === 0) {
+           return Promise.resolve(`\u26A0  |  No results for: \`${query}\``);
         }
         return Promise.resolve(R.repeat('tags', count))
         .map(() => {
@@ -151,13 +161,10 @@ function tags(client, evt, suffix) {
             url: 'http://furry.booru.org/index.php?page=post&s=view&id=' + id,
             description: imageDescription,
             image: { url: fileurl },
-            footer: { icon_url: 'http://i.imgur.com/zrdxCfF.png', text: 'furrybooru' }
+            footer: { icon_url: 'http://i.imgur.com/zrdxCfF.png', text: 'furrybooru · ' + currentPosition + '/' + count }
           };
 
           body.splice(randomid,1);
-
-          console.log('body3: ' + body);
-          console.log('bodylength3: ' + body.length);
 
           return evt.message.channel.sendMessage('', false, embed);
         });

--- a/src/commands/lewd/gelbooru.js
+++ b/src/commands/lewd/gelbooru.js
@@ -55,8 +55,8 @@ function tags(client, evt, suffix) {
       }
       let query;
       let lastTag = array[array.length - 1];
-      console.log('lastTag: ' + lastTag);
-      console.log('lastTag isNum: ' + isNumeric(lastTag));
+      //console.log('lastTag: ' + lastTag);
+      //console.log('lastTag isNum: ' + isNumeric(lastTag));
       let count = 1;
       if (suffix && isNumeric(lastTag)) {
         count = lastTag;
@@ -69,7 +69,7 @@ function tags(client, evt, suffix) {
         query = suffix.toLowerCase().replace('tags ', '');
       }
 
-      console.log('query: ' + query);
+      //console.log('query: ' + query);
 
       if (query === '') return Promise.resolve(`\u26A0  |  No tags were supplied`);
       let checkLength = query.split(' ');
@@ -93,25 +93,33 @@ function tags(client, evt, suffix) {
            return Promise.resolve(`\u26A0  |  No results for: \`${query}\``);
         }
         if (body) {
-          console.log('body: ' + body);
-          console.log('bodylength: ' + body.length);
+          //console.log('Body Before BL: ' + body);
+          //console.log('BodyLength Before BL: ' + body.length);
           let i;
           for (i = body.length - 1; i >= 0; i--) {
-            // Apply blacklisting
-            if (value) {
-              let tags = body[i].tags.split(' ');
-              if (findOne(blacklist, tags) || body[i].tags.includes('cub') || body[i].tags.includes('shota') || body[i].tags.includes('loli')) {
-                if (removeValue === 'true') {
-                  body.splice(i,1);
-                }
-              }
+            if (body[i].tags.includes('cub') || body[i].tags.includes('shota') || body[i].tags.includes('loli') || body[i].tags.includes('young')) {
+                body.splice(i,1);
             }
           }
+          //console.log('Body After Default BL: ' + body);
+          //console.log('BodyLength After Default BL: ' + body.length);
+          // Apply blacklisting strictness
+          if (value && removeValue === 'true') {
+            for (i = body.length - 1; i >= 0; i--) {
+              let tags = body[i].tags.split(' ');
+              if (findOne(blacklist, tags)) {
+                  body.splice(i,1);
+              }
+            }
+            //console.log('Body After Custom BL: ' + body);
+            //console.log('BodyLength After Custom BL: ' + body.length);
+          }
         }
-        console.log('body2: ' + body);
-        console.log('bodylength2: ' + body.length);
         if (count > body.length) {
           count = body.length;
+        }
+        if (!body || typeof body[0] === 'undefined' || typeof body === 'undefined' || body.length === 0) {
+           return Promise.resolve(`\u26A0  |  No results for: \`${query}\``);
         }
         return Promise.resolve(R.repeat('tags', count))
         .map(() => {
@@ -121,9 +129,7 @@ function tags(client, evt, suffix) {
           currentPosition++;
           // Grab the data
           let id = body[randomid].id;
-          let file = body[randomid].image;
-          let directory = body[randomid].directory;
-          let fileurl = `https://gelbooru.com/images/${directory}/${file}`;
+          let file = body[randomid].file_url;
           let height = body[randomid].height;
           let width = body[randomid].width;
           let score = body[randomid].score;
@@ -152,14 +158,11 @@ function tags(client, evt, suffix) {
             },
             url: 'http://gelbooru.com/index.php?page=post&s=view&id=' + id,
             description: imageDescription,
-            image: { url: fileurl },
-            footer: { icon_url: 'http://i.imgur.com/FZhHbKe.png', text: 'gelbooru' }
+            image: { url: file },
+            footer: { icon_url: 'http://i.imgur.com/FZhHbKe.png', text: 'gelbooru · ' + currentPosition + '/' + count }
           };
 
           body.splice(randomid,1);
-
-          console.log('body3: ' + body);
-          console.log('bodylength3: ' + body.length);
 
           return evt.message.channel.sendMessage('', false, embed);
         });

--- a/src/commands/lewd/gelbooru.js
+++ b/src/commands/lewd/gelbooru.js
@@ -12,7 +12,7 @@ function _makeRequest(options) {
   let default_options = {
     json: true,
     headers: {
-      'User-Agent': 'FurBot/1.0 (Phun @ e621)'
+      'User-Agent': 'PhunStyle/FurBot @ GitHub'
     }
   };
 
@@ -35,6 +35,10 @@ function getOne(haystack, arr) {
   return arr.find(v => haystack.includes(v));
 }
 
+function isNumeric(num){
+  return !isNaN(num);
+}
+
 function tags(client, evt, suffix) {
   return getBlackListRemove(evt.message.channel_id).then(removeValue => {
     let channelTest = evt.message.channel.nsfw;
@@ -50,9 +54,11 @@ function tags(client, evt, suffix) {
         }
       }
       let query;
-      let lastTag = Number.parseInt(array[array.length - 1], 10);
+      let lastTag = array[array.length - 1];
+      console.log('lastTag: ' + lastTag);
+      console.log('lastTag isNum: ' + isNumeric(lastTag));
       let count = 1;
-      if (suffix && Number.isInteger(lastTag)) {
+      if (suffix && isNumeric(lastTag)) {
         count = lastTag;
         if (count > 5) count = 5;
         if (count < 0) count = 1;
@@ -62,6 +68,8 @@ function tags(client, evt, suffix) {
       } else {
         query = suffix.toLowerCase().replace('tags ', '');
       }
+
+      console.log('query: ' + query);
 
       if (query === '') return Promise.resolve(`\u26A0  |  No tags were supplied`);
       let checkLength = query.split(' ');
@@ -84,8 +92,30 @@ function tags(client, evt, suffix) {
         if (!body || typeof body[0] === 'undefined' || typeof body === 'undefined' || body.length === 0) {
            return Promise.resolve(`\u26A0  |  No results for: \`${query}\``);
         }
+        if (body) {
+          console.log('body: ' + body);
+          console.log('bodylength: ' + body.length);
+          let i;
+          for (i = body.length - 1; i >= 0; i--) {
+            // Apply blacklisting
+            if (value) {
+              let tags = body[i].tags.split(' ');
+              if (findOne(blacklist, tags) || body[i].tags.includes('cub') || body[i].tags.includes('shota') || body[i].tags.includes('loli')) {
+                if (removeValue === 'true') {
+                  body.splice(i,1);
+                }
+              }
+            }
+          }
+        }
+        console.log('body2: ' + body);
+        console.log('bodylength2: ' + body.length);
+        if (count > body.length) {
+          count = body.length;
+        }
         return Promise.resolve(R.repeat('tags', count))
         .map(() => {
+          if (body.length === 0) return;
           // Do some math
           let randomid = Math.floor(Math.random() * body.length);
           currentPosition++;
@@ -97,10 +127,10 @@ function tags(client, evt, suffix) {
           let height = body[randomid].height;
           let width = body[randomid].width;
           let score = body[randomid].score;
-          let imageDescription = `**Score:** ${score} | **Resolution: ** ${width} x ${height} | **Link:** [Click Here](http://gelbooru.com/index.php?page=post&s=view&id=${id})`;
+          let imageDescription = `**Score:** ${score} | **Resolution: ** ${width} x ${height} | [**Link**](http://gelbooru.com/index.php?page=post&s=view&id=${id})`;
           if (file) {
             if (file.endsWith('webm') || file.endsWith('swf')) {
-              imageDescription = `**Score:** ${score} | **Link:** [Click Here](http://gelbooru.com/index.php?page=post&s=view&id=${id})\n*This file (webm/swf) cannot be previewed or embedded.*`;
+              imageDescription = `**Score:** ${score} | [**Link**](http://gelbooru.com/index.php?page=post&s=view&id=${id})\n*This file (webm/swf) cannot be previewed or embedded.*`;
             }
           }
 
@@ -108,17 +138,9 @@ function tags(client, evt, suffix) {
           if (value) {
             let tags = body[randomid].tags.split(' ');
             if (findOne(blacklist, tags)) {
-              if (removeValue === 'true') {
-                blacklistHits++;
-                if (blacklistHits > 0 && currentPosition === count) {
-                  return evt.message.channel.sendMessage('', false, {color: 4437377, description: `<:greenTick:405749911037018125> Skipped \`${blacklistHits}\` blacklisted results.`})
-                  .then(message => { setTimeout(() => { message.delete(); }, 5000); });
-                }
-                return;
-              }
               fileurl = null;
               let blacklistMatch = getOne(blacklist, tags);
-              imageDescription = `**BLACKLISTED** - Matched: \`${blacklistMatch}\` | **Link:** [Click Here](http://gelbooru.com/index.php?page=post&s=view&id=${id})`;
+              imageDescription = `**BLACKLISTED** - Matched: \`${blacklistMatch}\` | [**Link**](https://e621.net/post/show/${id})`;
             }
           }
 
@@ -133,6 +155,12 @@ function tags(client, evt, suffix) {
             image: { url: fileurl },
             footer: { icon_url: 'http://i.imgur.com/FZhHbKe.png', text: 'gelbooru' }
           };
+
+          body.splice(randomid,1);
+
+          console.log('body3: ' + body);
+          console.log('bodylength3: ' + body.length);
+
           return evt.message.channel.sendMessage('', false, embed);
         });
       });
@@ -143,7 +171,6 @@ function tags(client, evt, suffix) {
 export default {
   gb: (client, evt, suffix, lang) => {
     const command = suffix.toLowerCase().split(' ')[0];
-    // if (command === 'latest') return latest(client, evt, suffix);
     if (command === 'tags') return tags(client, evt, suffix);
     if (command !== 'tags' || command !== 'latest') return tags(client, evt, suffix);
   }

--- a/src/commands/lewd/konachan.js
+++ b/src/commands/lewd/konachan.js
@@ -12,7 +12,7 @@ function _makeRequest(options) {
   let default_options = {
     json: true,
     headers: {
-      'User-Agent': 'FurBot/1.0 (Phun @ e621)'
+      'User-Agent': 'PhunStyle/FurBot @ GitHub'
     }
   };
 
@@ -35,6 +35,10 @@ function getOne(haystack, arr) {
   return arr.find(v => haystack.includes(v));
 }
 
+function isNumeric(num){
+  return !isNaN(num);
+}
+
 function tags(client, evt, suffix) {
   return getBlackListRemove(evt.message.channel_id).then(removeValue => {
     let channelTest = evt.message.channel.nsfw;
@@ -50,9 +54,11 @@ function tags(client, evt, suffix) {
         }
       }
       let query;
-      let lastTag = Number.parseInt(array[array.length - 1], 10);
+      let lastTag = array[array.length - 1];
+      console.log('lastTag: ' + lastTag);
+      console.log('lastTag isNum: ' + isNumeric(lastTag));
       let count = 1;
-      if (suffix && Number.isInteger(lastTag)) {
+      if (suffix && isNumeric(lastTag)) {
         count = lastTag;
         if (count > 5) count = 5;
         if (count < 0) count = 1;
@@ -63,6 +69,8 @@ function tags(client, evt, suffix) {
         query = suffix.toLowerCase().replace('tags ', '');
       }
 
+      console.log('query: ' + query);
+
       if (query === '') return Promise.resolve(`\u26A0  |  No tags were supplied`);
       let checkLength = query.split(' ');
       if (checkLength.length > 6) return Promise.resolve(`\u26A0  |  You can only search up to 6 tags`);
@@ -70,7 +78,7 @@ function tags(client, evt, suffix) {
       const options = {
         url: `http://konachan.com/post/index.json?tags=${query}`,
         qs: {
-          limit: 300
+          limit: 200
         }
       };
 
@@ -83,22 +91,43 @@ function tags(client, evt, suffix) {
         if (!body || typeof body[0] === 'undefined' || typeof body === 'undefined' || body.length === 0) {
            return Promise.resolve(`\u26A0  |  No results for: \`${query}\``);
         }
+        if (body) {
+          console.log('body: ' + body);
+          console.log('bodylength: ' + body.length);
+          let i;
+          for (i = body.length - 1; i >= 0; i--) {
+            // Apply blacklisting
+            if (value) {
+              let tags = body[i].tags.split(' ');
+              if (findOne(blacklist, tags) || body[i].tags.includes('cub') || body[i].tags.includes('shota') || body[i].tags.includes('loli')) {
+                if (removeValue === 'true') {
+                  body.splice(i,1);
+                }
+              }
+            }
+          }
+        }
+        console.log('body2: ' + body);
+        console.log('bodylength2: ' + body.length);
+        if (count > body.length) {
+          count = body.length;
+        }
         return Promise.resolve(R.repeat('tags', count))
         .map(() => {
+          if (body.length === 0) return;
           // Do some math
           let randomid = Math.floor(Math.random() * body.length);
           currentPosition++;
           // Grab the data
           let id = body[randomid].id;
           let file = body[randomid].file_url;
-          let fileurl = `http:${file}`;
           let height = body[randomid].height;
           let width = body[randomid].width;
           let score = body[randomid].score;
-          let imageDescription = `**Score:** ${score} | **Resolution: ** ${width} x ${height} | **Link:** [Click Here](http://konachan.com/post/show/${id})`;
+          let imageDescription = `**Score:** ${score} | **Resolution: ** ${width} x ${height} | [**Link**](http://konachan.com/post/show/${id})`;
           if (file) {
             if (file.endsWith('webm') || file.endsWith('swf')) {
-              imageDescription = `**Score:** ${score} | **Link:** [Click Here](http://konachan.com/post/show/${id})\n*This file (webm/swf) cannot be previewed or embedded.*`;
+              imageDescription = `**Score:** ${score} | [**Link**](http://konachan.com/post/show/${id})\n*This file (webm/swf) cannot be previewed or embedded.*`;
             }
           }
 
@@ -106,17 +135,9 @@ function tags(client, evt, suffix) {
           if (value) {
             let tags = body[randomid].tags.split(' ');
             if (findOne(blacklist, tags)) {
-              if (removeValue === 'true') {
-                blacklistHits++;
-                if (blacklistHits > 0 && currentPosition === count) {
-                  return evt.message.channel.sendMessage('', false, {color: 4437377, description: `<:greenTick:405749911037018125> Skipped \`${blacklistHits}\` blacklisted results.`})
-                  .then(message => { setTimeout(() => { message.delete(); }, 5000); });
-                }
-                return;
-              }
-              fileurl = null;
+              file = null;
               let blacklistMatch = getOne(blacklist, tags);
-              imageDescription = `**BLACKLISTED** - Matched: \`${blacklistMatch}\` | **Link:** [Click Here](http://konachan.com/post/show/${id})`;
+              imageDescription = `**BLACKLISTED** - Matched: \`${blacklistMatch}\` | [**Link**](https://e621.net/post/show/${id})`;
             }
           }
 
@@ -128,9 +149,15 @@ function tags(client, evt, suffix) {
             },
             url: 'http://konachan.com/post/show/' + id,
             description: imageDescription,
-            image: { url: fileurl },
+            image: { url: file },
             footer: { icon_url: 'http://i.imgur.com/i6h2bnx.png', text: 'konachan' }
           };
+
+          body.splice(randomid,1);
+
+          console.log('body3: ' + body);
+          console.log('bodylength3: ' + body.length);
+
           return evt.message.channel.sendMessage('', false, embed);
         });
       });
@@ -141,7 +168,6 @@ function tags(client, evt, suffix) {
 export default {
   kc: (client, evt, suffix, lang) => {
     const command = suffix.toLowerCase().split(' ')[0];
-    // if (command === 'latest') return latest(client, evt, suffix);
     if (command === 'tags') return tags(client, evt, suffix);
     if (command !== 'tags' || command !== 'latest') return tags(client, evt, suffix);
   }

--- a/src/commands/lewd/konachan.js
+++ b/src/commands/lewd/konachan.js
@@ -55,8 +55,8 @@ function tags(client, evt, suffix) {
       }
       let query;
       let lastTag = array[array.length - 1];
-      console.log('lastTag: ' + lastTag);
-      console.log('lastTag isNum: ' + isNumeric(lastTag));
+      //console.log('lastTag: ' + lastTag);
+      //console.log('lastTag isNum: ' + isNumeric(lastTag));
       let count = 1;
       if (suffix && isNumeric(lastTag)) {
         count = lastTag;
@@ -69,7 +69,7 @@ function tags(client, evt, suffix) {
         query = suffix.toLowerCase().replace('tags ', '');
       }
 
-      console.log('query: ' + query);
+      //console.log('query: ' + query);
 
       if (query === '') return Promise.resolve(`\u26A0  |  No tags were supplied`);
       let checkLength = query.split(' ');
@@ -92,25 +92,33 @@ function tags(client, evt, suffix) {
            return Promise.resolve(`\u26A0  |  No results for: \`${query}\``);
         }
         if (body) {
-          console.log('body: ' + body);
-          console.log('bodylength: ' + body.length);
+          //console.log('Body Before BL: ' + body);
+          //console.log('BodyLength Before BL: ' + body.length);
           let i;
           for (i = body.length - 1; i >= 0; i--) {
-            // Apply blacklisting
-            if (value) {
-              let tags = body[i].tags.split(' ');
-              if (findOne(blacklist, tags) || body[i].tags.includes('cub') || body[i].tags.includes('shota') || body[i].tags.includes('loli')) {
-                if (removeValue === 'true') {
-                  body.splice(i,1);
-                }
-              }
+            if (body[i].tags.includes('cub') || body[i].tags.includes('shota') || body[i].tags.includes('loli') || body[i].tags.includes('young')) {
+                body.splice(i,1);
             }
           }
+          //console.log('Body After Default BL: ' + body);
+          //console.log('BodyLength After Default BL: ' + body.length);
+          // Apply blacklisting strictness
+          if (value && removeValue === 'true') {
+            for (i = body.length - 1; i >= 0; i--) {
+              let tags = body[i].tags.split(' ');
+              if (findOne(blacklist, tags)) {
+                  body.splice(i,1);
+              }
+            }
+            //console.log('Body After Custom BL: ' + body);
+            //console.log('BodyLength After Custom BL: ' + body.length);
+          }
         }
-        console.log('body2: ' + body);
-        console.log('bodylength2: ' + body.length);
         if (count > body.length) {
           count = body.length;
+        }
+        if (!body || typeof body[0] === 'undefined' || typeof body === 'undefined' || body.length === 0) {
+           return Promise.resolve(`\u26A0  |  No results for: \`${query}\``);
         }
         return Promise.resolve(R.repeat('tags', count))
         .map(() => {
@@ -150,13 +158,10 @@ function tags(client, evt, suffix) {
             url: 'http://konachan.com/post/show/' + id,
             description: imageDescription,
             image: { url: file },
-            footer: { icon_url: 'http://i.imgur.com/i6h2bnx.png', text: 'konachan' }
+            footer: { icon_url: 'http://i.imgur.com/i6h2bnx.png', text: 'konachan · ' + currentPosition + '/' + count }
           };
 
           body.splice(randomid,1);
-
-          console.log('body3: ' + body);
-          console.log('bodylength3: ' + body.length);
 
           return evt.message.channel.sendMessage('', false, embed);
         });

--- a/src/commands/lewd/rule34.js
+++ b/src/commands/lewd/rule34.js
@@ -55,8 +55,8 @@ function tags(client, evt, suffix) {
       }
       let query;
       let lastTag = array[array.length - 1];
-      console.log('lastTag: ' + lastTag);
-      console.log('lastTag isNum: ' + isNumeric(lastTag));
+      //console.log('lastTag: ' + lastTag);
+      //console.log('lastTag isNum: ' + isNumeric(lastTag));
       let count = 1;
       if (suffix && isNumeric(lastTag)) {
         count = lastTag;
@@ -69,7 +69,7 @@ function tags(client, evt, suffix) {
         query = suffix.toLowerCase().replace('tags ', '');
       }
 
-      console.log('query: ' + query);
+      //console.log('query: ' + query);
 
       if (query === '') return Promise.resolve(`\u26A0  |  No tags were supplied`);
       let checkLength = query.split(' ');
@@ -93,25 +93,33 @@ function tags(client, evt, suffix) {
            return Promise.resolve(`\u26A0  |  No results for: \`${query}\``);
         }
         if (body) {
-          console.log('body: ' + body);
-          console.log('bodylength: ' + body.length);
+          //console.log('Body Before BL: ' + body);
+          //console.log('BodyLength Before BL: ' + body.length);
           let i;
           for (i = body.length - 1; i >= 0; i--) {
-            // Apply blacklisting
-            if (value) {
-              let tags = body[i].tags.split(' ');
-              if (findOne(blacklist, tags) || body[i].tags.includes('cub') || body[i].tags.includes('shota') || body[i].tags.includes('loli')) {
-                if (removeValue === 'true') {
-                  body.splice(i,1);
-                }
-              }
+            if (body[i].tags.includes('cub') || body[i].tags.includes('shota') || body[i].tags.includes('loli') || body[i].tags.includes('young')) {
+                body.splice(i,1);
             }
           }
+          //console.log('Body After Default BL: ' + body);
+          //console.log('BodyLength After Default BL: ' + body.length);
+          // Apply blacklisting strictness
+          if (value && removeValue === 'true') {
+            for (i = body.length - 1; i >= 0; i--) {
+              let tags = body[i].tags.split(' ');
+              if (findOne(blacklist, tags)) {
+                  body.splice(i,1);
+              }
+            }
+            //console.log('Body After Custom BL: ' + body);
+            //console.log('BodyLength After Custom BL: ' + body.length);
+          }
         }
-        console.log('body2: ' + body);
-        console.log('bodylength2: ' + body.length);
         if (count > body.length) {
           count = body.length;
+        }
+        if (!body || typeof body[0] === 'undefined' || typeof body === 'undefined' || body.length === 0) {
+           return Promise.resolve(`\u26A0  |  No results for: \`${query}\``);
         }
         return Promise.resolve(R.repeat('tags', count))
         .map(() => {
@@ -153,13 +161,10 @@ function tags(client, evt, suffix) {
             url: 'http://rule34.xxx/index.php?page=post&s=view&id=' + id,
             description: imageDescription,
             image: { url: fileurl },
-            footer: { icon_url: 'http://i.imgur.com/JtqlUfF.png', text: 'rule34.xxx' }
+            footer: { icon_url: 'http://i.imgur.com/JtqlUfF.png', text: 'rule34.xxx · ' + currentPosition + '/' + count }
           };
 
           body.splice(randomid,1);
-
-          console.log('body3: ' + body);
-          console.log('bodylength3: ' + body.length);
 
           return evt.message.channel.sendMessage('', false, embed);
         });

--- a/src/commands/lewd/rule34.js
+++ b/src/commands/lewd/rule34.js
@@ -12,7 +12,7 @@ function _makeRequest(options) {
   let default_options = {
     json: true,
     headers: {
-      'User-Agent': 'FurBot/1.0 (Phun @ e621)'
+      'User-Agent': 'PhunStyle/FurBot @ GitHub'
     }
   };
 
@@ -35,6 +35,10 @@ function getOne(haystack, arr) {
   return arr.find(v => haystack.includes(v));
 }
 
+function isNumeric(num){
+  return !isNaN(num);
+}
+
 function tags(client, evt, suffix) {
   return getBlackListRemove(evt.message.channel_id).then(removeValue => {
     let channelTest = evt.message.channel.nsfw;
@@ -50,9 +54,11 @@ function tags(client, evt, suffix) {
         }
       }
       let query;
-      let lastTag = Number.parseInt(array[array.length - 1], 10);
+      let lastTag = array[array.length - 1];
+      console.log('lastTag: ' + lastTag);
+      console.log('lastTag isNum: ' + isNumeric(lastTag));
       let count = 1;
-      if (suffix && Number.isInteger(lastTag)) {
+      if (suffix && isNumeric(lastTag)) {
         count = lastTag;
         if (count > 5) count = 5;
         if (count < 0) count = 1;
@@ -62,6 +68,8 @@ function tags(client, evt, suffix) {
       } else {
         query = suffix.toLowerCase().replace('tags ', '');
       }
+
+      console.log('query: ' + query);
 
       if (query === '') return Promise.resolve(`\u26A0  |  No tags were supplied`);
       let checkLength = query.split(' ');
@@ -84,8 +92,30 @@ function tags(client, evt, suffix) {
         if (!body || typeof body[0] === 'undefined' || typeof body === 'undefined' || body.length === 0) {
            return Promise.resolve(`\u26A0  |  No results for: \`${query}\``);
         }
+        if (body) {
+          console.log('body: ' + body);
+          console.log('bodylength: ' + body.length);
+          let i;
+          for (i = body.length - 1; i >= 0; i--) {
+            // Apply blacklisting
+            if (value) {
+              let tags = body[i].tags.split(' ');
+              if (findOne(blacklist, tags) || body[i].tags.includes('cub') || body[i].tags.includes('shota') || body[i].tags.includes('loli')) {
+                if (removeValue === 'true') {
+                  body.splice(i,1);
+                }
+              }
+            }
+          }
+        }
+        console.log('body2: ' + body);
+        console.log('bodylength2: ' + body.length);
+        if (count > body.length) {
+          count = body.length;
+        }
         return Promise.resolve(R.repeat('tags', count))
         .map(() => {
+          if (body.length === 0) return;
           // Do some math
           let randomid = Math.floor(Math.random() * body.length);
           currentPosition++;
@@ -97,10 +127,10 @@ function tags(client, evt, suffix) {
           let height = body[randomid].height;
           let width = body[randomid].width;
           let score = body[randomid].score;
-          let imageDescription = `**Score:** ${score} | **Resolution: ** ${width} x ${height} | **Link:** [Click Here](http://rule34.xxx/index.php?page=post&s=view&id=${id})`;
+          let imageDescription = `**Score:** ${score} | **Resolution: ** ${width} x ${height} | [**Link**](http://rule34.xxx/index.php?page=post&s=view&id=${id})`;
           if (file) {
             if (file.endsWith('webm') || file.endsWith('swf')) {
-              imageDescription = `**Score:** ${score} | **Link:** [Click Here](http://rule34.xxx/index.php?page=post&s=view&id=${id})\n*This file (webm/swf) cannot be previewed or embedded.*`;
+              imageDescription = `**Score:** ${score} | [**Link**](http://rule34.xxx/index.php?page=post&s=view&id=${id})\n*This file (webm/swf) cannot be previewed or embedded.*`;
             }
           }
 
@@ -108,17 +138,9 @@ function tags(client, evt, suffix) {
           if (value) {
             let tags = body[randomid].tags.split(' ');
             if (findOne(blacklist, tags)) {
-              if (removeValue === 'true') {
-                blacklistHits++;
-                if (blacklistHits > 0 && currentPosition === count) {
-                  return evt.message.channel.sendMessage('', false, {color: 4437377, description: `<:greenTick:405749911037018125> Skipped \`${blacklistHits}\` blacklisted results.`})
-                  .then(message => { setTimeout(() => { message.delete(); }, 5000); });
-                }
-                return;
-              }
-              fileurl = null;
+              fileurl= null;
               let blacklistMatch = getOne(blacklist, tags);
-              imageDescription = `**BLACKLISTED** - Matched: \`${blacklistMatch}\` | **Link:** [Click Here](http://rule34.xxx/index.php?page=post&s=view&id=${id})`;
+              imageDescription = `**BLACKLISTED** - Matched: \`${blacklistMatch}\` | [**Link**](https://e621.net/post/show/${id})`;
             }
           }
 
@@ -133,6 +155,12 @@ function tags(client, evt, suffix) {
             image: { url: fileurl },
             footer: { icon_url: 'http://i.imgur.com/JtqlUfF.png', text: 'rule34.xxx' }
           };
+
+          body.splice(randomid,1);
+
+          console.log('body3: ' + body);
+          console.log('bodylength3: ' + body.length);
+
           return evt.message.channel.sendMessage('', false, embed);
         });
       });
@@ -143,7 +171,6 @@ function tags(client, evt, suffix) {
 export default {
   r34: (client, evt, suffix, lang) => {
     const command = suffix.toLowerCase().split(' ')[0];
-    // if (command === 'latest') return latest(client, evt, suffix);
     if (command === 'tags') return tags(client, evt, suffix);
     if (command !== 'tags' || command !== 'latest') return tags(client, evt, suffix);
   }

--- a/src/commands/lewd/yandere.js
+++ b/src/commands/lewd/yandere.js
@@ -12,7 +12,7 @@ function _makeRequest(options) {
   let default_options = {
     json: true,
     headers: {
-      'User-Agent': 'FurBot/1.0 (Phun @ e621)'
+      'User-Agent': 'PhunStyle/FurBot @ GitHub'
     }
   };
 
@@ -35,6 +35,10 @@ function getOne(haystack, arr) {
   return arr.find(v => haystack.includes(v));
 }
 
+function isNumeric(num){
+  return !isNaN(num);
+}
+
 function tags(client, evt, suffix) {
   return getBlackListRemove(evt.message.channel_id).then(removeValue => {
     let channelTest = evt.message.channel.nsfw;
@@ -50,9 +54,11 @@ function tags(client, evt, suffix) {
         }
       }
       let query;
-      let lastTag = Number.parseInt(array[array.length - 1], 10);
+      let lastTag = array[array.length - 1];
+      console.log('lastTag: ' + lastTag);
+      console.log('lastTag isNum: ' + isNumeric(lastTag));
       let count = 1;
-      if (suffix && Number.isInteger(lastTag)) {
+      if (suffix && isNumeric(lastTag)) {
         count = lastTag;
         if (count > 5) count = 5;
         if (count < 0) count = 1;
@@ -62,6 +68,8 @@ function tags(client, evt, suffix) {
       } else {
         query = suffix.toLowerCase().replace('tags ', '');
       }
+
+      console.log('query: ' + query);
 
       if (query === '') return Promise.resolve(`\u26A0  |  No tags were supplied`);
       let checkLength = query.split(' ');
@@ -83,8 +91,30 @@ function tags(client, evt, suffix) {
         if (!body || typeof body[0] === 'undefined' || typeof body === 'undefined' || body.length === 0) {
            return Promise.resolve(`\u26A0  |  No results for: \`${query}\``);
         }
+        if (body) {
+          console.log('body: ' + body);
+          console.log('bodylength: ' + body.length);
+          let i;
+          for (i = body.length - 1; i >= 0; i--) {
+            // Apply blacklisting
+            if (value) {
+              let tags = body[i].tags.split(' ');
+              if (findOne(blacklist, tags) || body[i].tags.includes('cub') || body[i].tags.includes('shota') || body[i].tags.includes('loli')) {
+                if (removeValue === 'true') {
+                  body.splice(i,1);
+                }
+              }
+            }
+          }
+        }
+        console.log('body2: ' + body);
+        console.log('bodylength2: ' + body.length);
+        if (count > body.length) {
+          count = body.length;
+        }
         return Promise.resolve(R.repeat('tags', count))
         .map(() => {
+          if (body.length === 0) return;
           // Do some math
           let randomid = Math.floor(Math.random() * body.length);
           currentPosition++;
@@ -94,10 +124,10 @@ function tags(client, evt, suffix) {
           let height = body[randomid].height;
           let width = body[randomid].width;
           let score = body[randomid].score;
-          let imageDescription = `**Score:** ${score} | **Resolution: ** ${width} x ${height} | **Link:** [Click Here](https://yande.re/post/show/${id})`;
+          let imageDescription = `**Score:** ${score} | **Resolution: ** ${width} x ${height} | [**Link**](https://yande.re/post/show/${id})`;
           if (file) {
             if (file.endsWith('webm') || file.endsWith('swf')) {
-              imageDescription = `**Score:** ${score} | **Link:** [Click Here](https://yande.re/post/show/${id})\n*This file (webm/swf) cannot be previewed or embedded.*`;
+              imageDescription = `**Score:** ${score} | [**Link**](https://yande.re/post/show/${id})\n*This file (webm/swf) cannot be previewed or embedded.*`;
             }
           }
 
@@ -105,17 +135,9 @@ function tags(client, evt, suffix) {
           if (value) {
             let tags = body[randomid].tags.split(' ');
             if (findOne(blacklist, tags)) {
-              if (removeValue === 'true') {
-                blacklistHits++;
-                if (blacklistHits > 0 && currentPosition === count) {
-                  return evt.message.channel.sendMessage('', false, {color: 4437377, description: `<:greenTick:405749911037018125> Skipped \`${blacklistHits}\` blacklisted results.`})
-                  .then(message => { setTimeout(() => { message.delete(); }, 5000); });
-                }
-                return;
-              }
               file = null;
               let blacklistMatch = getOne(blacklist, tags);
-              imageDescription = `**BLACKLISTED** - Matched: \`${blacklistMatch}\` | **Link:** [Click Here](https://yande.re/post/show/${id})`;
+              imageDescription = `**BLACKLISTED** - Matched: \`${blacklistMatch}\` | [**Link**](https://e621.net/post/show/${id})`;
             }
           }
 
@@ -130,6 +152,12 @@ function tags(client, evt, suffix) {
             image: { url: file },
             footer: { icon_url: 'http://i.imgur.com/Gq1SpOc.png', text: 'yandere' }
           };
+
+          body.splice(randomid,1);
+
+          console.log('body3: ' + body);
+          console.log('bodylength3: ' + body.length);
+
           return evt.message.channel.sendMessage('', false, embed);
         });
       });
@@ -140,7 +168,6 @@ function tags(client, evt, suffix) {
 export default {
   yd: (client, evt, suffix, lang) => {
     const command = suffix.toLowerCase().split(' ')[0];
-    // if (command === 'latest') return latest(client, evt, suffix);
     if (command === 'tags') return tags(client, evt, suffix);
     if (command !== 'tags' || command !== 'latest') return tags(client, evt, suffix);
   }

--- a/src/commands/lewd/yandere.js
+++ b/src/commands/lewd/yandere.js
@@ -55,8 +55,8 @@ function tags(client, evt, suffix) {
       }
       let query;
       let lastTag = array[array.length - 1];
-      console.log('lastTag: ' + lastTag);
-      console.log('lastTag isNum: ' + isNumeric(lastTag));
+      //console.log('lastTag: ' + lastTag);
+      //console.log('lastTag isNum: ' + isNumeric(lastTag));
       let count = 1;
       if (suffix && isNumeric(lastTag)) {
         count = lastTag;
@@ -69,7 +69,7 @@ function tags(client, evt, suffix) {
         query = suffix.toLowerCase().replace('tags ', '');
       }
 
-      console.log('query: ' + query);
+      //console.log('query: ' + query);
 
       if (query === '') return Promise.resolve(`\u26A0  |  No tags were supplied`);
       let checkLength = query.split(' ');
@@ -92,25 +92,33 @@ function tags(client, evt, suffix) {
            return Promise.resolve(`\u26A0  |  No results for: \`${query}\``);
         }
         if (body) {
-          console.log('body: ' + body);
-          console.log('bodylength: ' + body.length);
+          //console.log('Body Before BL: ' + body);
+          //console.log('BodyLength Before BL: ' + body.length);
           let i;
           for (i = body.length - 1; i >= 0; i--) {
-            // Apply blacklisting
-            if (value) {
-              let tags = body[i].tags.split(' ');
-              if (findOne(blacklist, tags) || body[i].tags.includes('cub') || body[i].tags.includes('shota') || body[i].tags.includes('loli')) {
-                if (removeValue === 'true') {
-                  body.splice(i,1);
-                }
-              }
+            if (body[i].tags.includes('cub') || body[i].tags.includes('shota') || body[i].tags.includes('loli') || body[i].tags.includes('young')) {
+                body.splice(i,1);
             }
           }
+          //console.log('Body After Default BL: ' + body);
+          //console.log('BodyLength After Default BL: ' + body.length);
+          // Apply blacklisting strictness
+          if (value && removeValue === 'true') {
+            for (i = body.length - 1; i >= 0; i--) {
+              let tags = body[i].tags.split(' ');
+              if (findOne(blacklist, tags)) {
+                  body.splice(i,1);
+              }
+            }
+            //console.log('Body After Custom BL: ' + body);
+            //console.log('BodyLength After Custom BL: ' + body.length);
+          }
         }
-        console.log('body2: ' + body);
-        console.log('bodylength2: ' + body.length);
         if (count > body.length) {
           count = body.length;
+        }
+        if (!body || typeof body[0] === 'undefined' || typeof body === 'undefined' || body.length === 0) {
+           return Promise.resolve(`\u26A0  |  No results for: \`${query}\``);
         }
         return Promise.resolve(R.repeat('tags', count))
         .map(() => {
@@ -150,13 +158,10 @@ function tags(client, evt, suffix) {
             url: 'https://yande.re/post/show/' + id,
             description: imageDescription,
             image: { url: file },
-            footer: { icon_url: 'http://i.imgur.com/Gq1SpOc.png', text: 'yandere' }
+            footer: { icon_url: 'http://i.imgur.com/Gq1SpOc.png', text: 'yandere · ' + currentPosition + '/' + count }
           };
 
           body.splice(randomid,1);
-
-          console.log('body3: ' + body);
-          console.log('bodylength3: ' + body.length);
 
           return evt.message.channel.sendMessage('', false, embed);
         });

--- a/src/commands/other.js
+++ b/src/commands/other.js
@@ -17,36 +17,7 @@ export default {
   kappa: () => Promise.resolve({upload: path.join(__dirname, '../images/Kappa.png')}),
   kappahd: () => Promise.resolve({upload: path.join(__dirname, '../images/Kappahd.png')}),
   doot: () => Promise.resolve('https://i.imgur.com/ZX79Q4S.gif'),
-  party: () => Promise.resolve('. o ･ <a:blobparty9:403304364850020354><a:blobparty8:403304364950814722><a:blobparty7:403304365169049622><a:blobparty6:403304365139558401><a:blobparty5:403304365542211594><a:blobparty4:403304365802127360><a:blobparty3:403304365638811658><a:blobparty2:403304364984238093><a:blobparty1:403304365370114059> ･ o .'),
-  newyear: () => Promise.resolve(`⁣⁣◼️◼️◼️◼️◼️◼️◼️◼️
-◼️◼️◼️🌟◼️◼️◼️◼️
-◼️◼️🌟🌟🌟🌟◼️◼️
-◼️🌟💥💥🌟💥✨◼️
-◼️◼️🌟🌟💥🌟◼️◼️
-◼️◼️◼️⁣🌟🌟◼️◼️◼️
-◼️◼️◼️◼️◼️◼️◼️◼️
-HAPPY NEW YEAR!!
-◼️◼️◼️◼️◼️◼️◼️◼️
-🏫🏠🏡🏫🏩🏪🏡🏠
-    👫👬👫👭`),
-  xmastree: () => Promise.resolve(`
-    ✨。          🌟。    ❇
-   。             🎄         。。
-      ❇    🎄🎄。 。   ✨
- ❇        🎄🔴🎄   💫。
-      。 🎄🔴🎀🎄 。❇
-  。   🎄🎀🎄🔴🎄。。
-    ✨ 🎄🎄🎀🎄。
-。。🎄🎄🔴🎄🎄。 ❇
-    🎄🎄🎀🎄🔴🎄
- 🎄🔴🎄🎄🎀🎄🎄
-。 🎄🎀🎄🎄🔴🎄      ✨
-  🎄🎄🔴🎄🎄🎀🎄
-🎄🔴🎄🎀🔴🎄🎄🎄
-\u200b                📦📦📦
-\u200b            📦📦📦📦
-<:santacat:525293333958885376> **HAPPY HOLIDAYS** <:santacat:525293333958885376>`),
-
+  party: () => Promise.resolve('. o ･ <a:blobparty9:403304364850020354><a:blobparty8:403304364950814722><a:blobparty7:403304365169049622><a:blobparty6:403304365139558401><a:blobparty5:403304365542211594><a:blobparty4:403304365802127360><a:blobparty3:403304365638811658><a:blobparty2:403304364984238093><a:blobparty1:403304365370114059> ･ o .')
 };
 
 export const help = {
@@ -63,5 +34,6 @@ export const help = {
   jpeg: {category: 'other'},
   kappa: {category: 'other'},
   kappahd: {category: 'other'},
-  doot: {category: 'other'}
+  doot: {category: 'other'},
+  party: {category: 'other'}
 };

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -23,6 +23,11 @@ export function cleanName(string) {
   return string.replace(/[*_~@]/g, m => chars[m]);
 }
 
+export function cleanSay(string) {
+  var chars = { '@': '@\u200b' };
+  return string.replace(/[@]/g, m => chars[m]);
+}
+
 // return an array of objects according to key, value, or key and value matching
 export function getObjects(obj, key, val) {
   var objects = [];


### PR DESCRIPTION
<a name="4.4.5" />

# 4.4.5 (February 25th, 2019)

### Features
- [NEW] `blacklist strict` will now remove blacklisted results completely and, if possible, add a non blacklisted result.
So for example, you will no longer get 3 images if you searched for 5 but 2 were blacklisted. The bot will now try to get
you 5 images all the time, unless the results page only contained 5 (or less) images to begin with.

- [NEW] `cub`, `loli`, `young` and `shota` are now blacklisted by default since these artworks are not allowed under discord ToS.
You do not need to add or remove them from your own blacklists, these are hardcoded in.

### Bug Fixes
- [FIX] Removed the possibility of finding duplicate images in the image results for the lewd commands.
- [FIX] Fixed a long standing bug where if the artist name contained a number the lewd commands would not work properly.
- [FIX] Fixed some lewd commands (konachan, danbooru, gelbooru) that were no longer working, they are all working now.
- [FIX] The say command no longer removes markdown (you can't use @ still)

### Notes
- [REMOVED] The christmas commands. It's february alright, get over it!