### PR TITLE
4.4.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ rethinkdb_data
 # Do not upload PM2 Config
 sharding.json
 sharding_test.json
+
+# Do not upload this script
+scripts/sharding/mvdb.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,18 @@
 
 # 4.4.6 (March 28th, 2019)
 
+### Features
+- [NEW] You can now change FurBot's prefix with the `prefix` command, only users with
+`MANAGE SERVER` permissions can use this command. You can only have a single or double
+character prefix. Only certain characters are allowed.
+
 ### Bug Fixes
 - [FIX] Searching for example `cubone` on the lewd commands no longer triggers the blacklist.
 - [FIX] You can now use `previous`, image links and attachments on the `pride` image command.
+- [FIX] The `word` command now doesn't turn multiple regional_indicator emoji into a Flag.
+
+### Notes
+- [NEW] FurBot now scrolls through several Playing statuses displaying some random texts or commands.
 
 
 <a name="4.4.5" />

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+<a name="4.4.6" />
+
+# 4.4.6 (March 28th, 2019)
+
+### Bug Fixes
+- [FIX] Searching for example `cubone` on the lewd commands no longer triggers the blacklist.
+- [FIX] You can now use `previous`, image links and attachments on the `pride` image command.
+
+
 <a name="4.4.5" />
 
 # 4.4.5 (March 8th, 2019)

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -146,6 +146,7 @@
   "poll_usage": "Usage: **`f.poll`** `title/question | option 1, option 2, option 3, etc`",
   "popkey_setup": "Please setup Popkey in config.js to use the **`f.popkey`** command.",
   "popkey_usage": "Usage: **`f.popkey`** `gif tags`",
+  "prefix": "Give FurBot a new prefix on the server!",
   "pride": "Turn your boring avatar into one for Pride Month. Show your colors!",
   "pride_usage": "Usage: `f.pride flagname` | Optionally you can add `rotated` for a rotated background. Or `border` for just the border (if your avatar is transparent). Or `overlay` to put the flag OVER your avatar. Or `background` if you want the flag as background.\n\nAvailable flagnames are:\n`ace`, `bisexual`, `genderfluid`, `genderqueer`, `lesbian`, `nonbinary`, `pansexual`, `rainbow`, `transgender`\n\nHappy pride month! <:prideMonth:454267469226311681>",
   "prune": "Prune the given amount of messages. If no number is written, prunes 10. (Max 100)",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "babel-polyfill": "^6.23.0",
     "babel-preset-es2015-node4": "^2.0.2",
     "babel-preset-stage-1": "^6.3.13",
-    "bluebird": "^3.1.1",
+    "bluebird": "^3.5.3",
     "body-parser": "^1.14.2",
     "bunyan": "^1.8.1",
     "chalk": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "dev": "NODE_ENV=development DEBUG=express:*,horseman nodemon -i **/*.marko.js -e js,marko ./index.js",
     "dev-nodebug": "NODE_ENV=development nodemon -i **/*.marko.js -e js,marko ./index.js",
     "dev-sharding": "babel-node ./scripts/sharding/dev.js",
+    "mvdb": "babel-node ./scripts/sharding/mvdb.js",
     "docker": "npm run test && docker build --rm -t gravebot/gravebot:latest . && docker push gravebot/gravebot:latest",
     "forever": "forever --minUptime 5000 index.js",
     "image": "docker build --rm -t gravebot/gravebot:latest .",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "furbot",
-  "version": "4.4.5",
+  "version": "4.4.6",
   "description": "A furry bot for Discord",
   "main": "index.js",
   "dependencies": {

--- a/src/commands/images/pride.js
+++ b/src/commands/images/pride.js
@@ -2,10 +2,14 @@ import Promise from 'bluebird';
 import request from 'request';
 import path from 'path';
 import T from '../../translate';
+
+import { getImageLink } from '../../helpers';
 var gm = require('gm').subClass({imageMagick: true});
 
 
 function pride(client, evt, suffix, lang) {
+  let data = getImageLink(client, evt, suffix, true);
+
   let flagSuffix = suffix.split(' ')[0];
   let flagArray = ['ace', 'bisexual', 'genderfluid', 'genderqueer', 'lesbian', 'nonbinary', 'pansexual', 'rainbow', 'transgender'];
   let validSuffix = (flagArray.indexOf(flagSuffix) > -1);
@@ -18,7 +22,9 @@ function pride(client, evt, suffix, lang) {
     return Promise.resolve(`${T('pride_usage', lang)}`);
   }
 
-  let imageLink = evt.message.author.getAvatarURL({format: 'png', size: 512, preferAnimated: false});
+  let image = data[1];
+
+  //let imageLink = evt.message.author.getAvatarURL({format: 'png', size: 512, preferAnimated: false});
 
   let prideFlag = flagSuffix;
 
@@ -32,7 +38,7 @@ function pride(client, evt, suffix, lang) {
 
   if (!doOverlay && !doBackground) {
     return new Promise((resolve, reject) => {
-      gm(request(imageLink))
+      gm(request(image))
       .resize('236', '236')
       // .crop(236, 236, 0, 0)
       .write(output, (err, buf) => {
@@ -68,7 +74,7 @@ function pride(client, evt, suffix, lang) {
 
   if (doOverlay) {
     return new Promise((resolve, reject) => {
-      gm(request(imageLink))
+      gm(request(image))
       .resize('256', '256')
       // .crop(236, 236, 0, 0)
       .write(output, (err, buf) => {
@@ -103,7 +109,7 @@ function pride(client, evt, suffix, lang) {
 
   if (doBackground) {
     return new Promise((resolve, reject) => {
-      gm(request(imageLink))
+      gm(request(image))
       .resize('256', '256')
       // .crop(236, 236, 0, 0)
       .write(output, (err, buf) => {

--- a/src/commands/lewd/danbooru.js
+++ b/src/commands/lewd/danbooru.js
@@ -96,7 +96,8 @@ function tags(client, evt, suffix) {
           //console.log('BodyLength Before BL: ' + body.length);
           let i;
           for (i = body.length - 1; i >= 0; i--) {
-            if (body[i].tag_string.includes('cub') || body[i].tag_string.includes('shota') || body[i].tag_string.includes('loli') || body[i].tag_string.includes('young')) {
+            let tagsArray = body[i].tag_string.split(' ');
+            if (tagsArray.includes('cub') || tagsArray.includes('shota') || tagsArray.includes('loli') || tagsArray.includes('young')) {
                 body.splice(i,1);
             }
           }

--- a/src/commands/lewd/derpibooru.js
+++ b/src/commands/lewd/derpibooru.js
@@ -111,7 +111,8 @@ function tags(client, evt, suffix) {
             //console.log('BodyLength Before BL: ' + body.search.length);
             let i;
             for (i = body.search.length - 1; i >= 0; i--) {
-              if (body.search[i].tags.includes('cub') || body.search[i].tags.includes('shota') || body.search[i].tags.includes('loli') || body.search[i].tags.includes('foalcon')) {
+              let tagsArray = body.search[i].tags.split(' ');
+              if (tagsArray.includes('cub') || tagsArray.includes('shota') || tagsArray.includes('loli') || tagsArray.includes('foalcon')) {
                   body.search.splice(i,1);
               }
             }

--- a/src/commands/lewd/e621.js
+++ b/src/commands/lewd/e621.js
@@ -96,7 +96,8 @@ function tags(client, evt, suffix) {
           //console.log('BodyLength Before BL: ' + body.length);
           let i;
           for (i = body.length - 1; i >= 0; i--) {
-            if (body[i].tags.includes('cub') || body[i].tags.includes('shota') || body[i].tags.includes('loli') || body[i].tags.includes('young')) {
+            let tagsArray = body[i].tags.split(' ');
+            if (tagsArray.includes('cub') || tagsArray.includes('shota') || tagsArray.includes('loli') || tagsArray.includes('young')) {
                 body.splice(i,1);
             }
           }

--- a/src/commands/lewd/furrybooru.js
+++ b/src/commands/lewd/furrybooru.js
@@ -97,7 +97,8 @@ function tags(client, evt, suffix) {
           //console.log('BodyLength Before BL: ' + body.length);
           let i;
           for (i = body.length - 1; i >= 0; i--) {
-            if (body[i].tags.includes('cub') || body[i].tags.includes('shota') || body[i].tags.includes('loli') || body[i].tags.includes('young')) {
+            let tagsArray = body[i].tags.split(' ');
+            if (tagsArray.includes('cub') || tagsArray.includes('shota') || tagsArray.includes('loli') || tagsArray.includes('young')) {
                 body.splice(i,1);
             }
           }

--- a/src/commands/lewd/gelbooru.js
+++ b/src/commands/lewd/gelbooru.js
@@ -97,7 +97,8 @@ function tags(client, evt, suffix) {
           //console.log('BodyLength Before BL: ' + body.length);
           let i;
           for (i = body.length - 1; i >= 0; i--) {
-            if (body[i].tags.includes('cub') || body[i].tags.includes('shota') || body[i].tags.includes('loli') || body[i].tags.includes('young')) {
+            let tagsArray = body[i].tags.split(' ');
+            if (tagsArray.includes('cub') || tagsArray.includes('shota') || tagsArray.includes('loli') || tagsArray.includes('young')) {
                 body.splice(i,1);
             }
           }

--- a/src/commands/lewd/konachan.js
+++ b/src/commands/lewd/konachan.js
@@ -96,7 +96,8 @@ function tags(client, evt, suffix) {
           //console.log('BodyLength Before BL: ' + body.length);
           let i;
           for (i = body.length - 1; i >= 0; i--) {
-            if (body[i].tags.includes('cub') || body[i].tags.includes('shota') || body[i].tags.includes('loli') || body[i].tags.includes('young')) {
+            let tagsArray = body[i].tags.split(' ');
+            if (tagsArray.includes('cub') || tagsArray.includes('shota') || tagsArray.includes('loli') || tagsArray.includes('young')) {
                 body.splice(i,1);
             }
           }

--- a/src/commands/lewd/rule34.js
+++ b/src/commands/lewd/rule34.js
@@ -97,7 +97,8 @@ function tags(client, evt, suffix) {
           //console.log('BodyLength Before BL: ' + body.length);
           let i;
           for (i = body.length - 1; i >= 0; i--) {
-            if (body[i].tags.includes('cub') || body[i].tags.includes('shota') || body[i].tags.includes('loli') || body[i].tags.includes('young')) {
+            let tagsArray = body[i].tags.split(' ');
+            if (tagsArray.includes('cub') || tagsArray.includes('shota') || tagsArray.includes('loli') || tagsArray.includes('young')) {
                 body.splice(i,1);
             }
           }

--- a/src/commands/lewd/yandere.js
+++ b/src/commands/lewd/yandere.js
@@ -96,7 +96,8 @@ function tags(client, evt, suffix) {
           //console.log('BodyLength Before BL: ' + body.length);
           let i;
           for (i = body.length - 1; i >= 0; i--) {
-            if (body[i].tags.includes('cub') || body[i].tags.includes('shota') || body[i].tags.includes('loli') || body[i].tags.includes('young')) {
+            let tagsArray = body[i].tags.split(' ');
+            if (tagsArray.includes('cub') || tagsArray.includes('shota') || tagsArray.includes('loli') || tagsArray.includes('young')) {
                 body.splice(i,1);
             }
           }

--- a/src/commands/moderation/prefix.js
+++ b/src/commands/moderation/prefix.js
@@ -1,0 +1,32 @@
+import { setGuildPrefix, getGuildPrefix } from '../../redis';
+
+function prefix(client, evt, suffix) {
+  if (evt.message.channel.isPrivate) return evt.message.channel.sendMessage('', false, {color: 3901635, description: `\u2139 Use this command in a server!`});
+  let userPerms = evt.message.author.permissionsFor(evt.message.guild);
+  if (evt.message.author.can(userPerms.General.MANAGE_GUILD, evt.message.guild)) {
+    let prefixToSet = suffix;
+
+    if (prefixToSet.length > 2 || prefixToSet.length < 1) return evt.message.channel.sendMessage('', false, {color: 16763981, description: `\u26A0 Prefix can only be 1 or 2 characters long!`});
+
+    let result;
+    const patt = new RegExp(/[A-Za-z0-9_.,!^*\-+=$&%@#?]{1}/i);
+    const patt2 = new RegExp(/[A-Za-z0-9_.,!^*\-+=$&%@#?]{2}/i);
+    if (prefixToSet.length === 1) result = patt.test(prefixToSet);
+    if (prefixToSet.length === 2) result = patt2.test(prefixToSet);
+
+    if (!result) return evt.message.channel.sendMessage('', false, {color: 16763981, description: `\u26A0 Prefix can only contain \`A-Z a-z 0-9 _ , . ! ^ * - + = $ & % # @ ?\``});
+
+    return setGuildPrefix(evt.message.guild.id, prefixToSet)
+    .then(() => evt.message.channel.sendMessage('', false, {color: 4437377, description: `<:greenTick:405749911037018125> New prefix \`${prefixToSet}\` has been set!`}));
+  };
+
+  return evt.message.channel.sendMessage('', false, {color: 16763981, description: `\u26A0  You do not have the "Manage Server" permission.`});
+}
+
+export default {
+  prefix
+};
+
+export const help = {
+  prefix: { parameters: 'prefix' }
+};

--- a/src/commands/useful/word.js
+++ b/src/commands/useful/word.js
@@ -7,7 +7,7 @@ function word(client, evt) {
   let regionalArray = [];
 
   dissect.map(character => {
-    let regionalCharacter = ':regional_indicator_' + character + ':';
+    let regionalCharacter = ':regional_indicator_' + character + ':\u200b';
     regionalArray.push(regionalCharacter);
   })
 

--- a/src/discord.js
+++ b/src/discord.js
@@ -12,6 +12,7 @@ import { init as initPhantom } from './phantom';
 
 import { startPortalTimeouts, startPortalIntervals } from './portals';
 import {
+  getGuildPrefix,
   getMessageTTL,
   setMessageTTL,
   getUserLang,
@@ -102,14 +103,30 @@ function onMessage(evt) {
   if (client.User.id === evt.message.author.id) return;
   if (evt.message.author.bot) return;
 
-  // Checks for PREFIX
-  if (evt.message.content.toLowerCase().startsWith(bot_prefix)) {
-    const command = evt.message.content.toLowerCase().split(' ')[0].substring(bot_prefix.length);
-    const suffix = evt.message.content.substring(command.length + bot_prefix.length + 1);
-    const cmd = commands[command];
+  if (!evt.message.channel.isPrivate) {
+    getGuildPrefix(evt.message.guild.id).then(guildPrefix => {
+      // Checks for PREFIX
+      if (evt.message.content.toLowerCase().startsWith(guildPrefix)) {
+        const command = evt.message.content.toLowerCase().split(' ')[0].substring(guildPrefix.length);
+        const suffix = evt.message.content.substring(command.length + guildPrefix.length + 1);
+        const cmd = commands[command];
 
-    if (cmd) callCmd(cmd, command, client, evt, suffix);
-    return;
+        if (cmd) callCmd(cmd, command, client, evt, suffix);
+        return;
+      }
+    });
+  }
+
+  if (evt.message.channel.isPrivate) {
+    // Checks for PREFIX
+    if (evt.message.content.toLowerCase().startsWith(bot_prefix)) {
+      const command = evt.message.content.toLowerCase().split(' ')[0].substring(bot_prefix.length);
+      const suffix = evt.message.content.substring(command.length + bot_prefix.length + 1);
+      const cmd = commands[command];
+
+      if (cmd) callCmd(cmd, command, client, evt, suffix);
+      return;
+    }
   }
 
   // Checks if bot was mentioned
@@ -166,9 +183,24 @@ function connect() {
 }
 
 function forceSetGame() {
-  logger.info('Setting Game');
-  client.User.setGame(`${bot_prefix}help | ${bot_prefix}info`);
+  setInterval(() => {
+    logger.info('Changing Game');
+    let gameArray = [
+      '@FurBot help',
+      '@FurBot info',
+      '@FurBot version',
+      'with beans',
+      'with Esix',
+      'with Node.JS',
+      'with furries',
+      'with tails',
+      'with paws'
+    ];
+    let randomGame = Math.floor(Math.random() * gameArray.length);
+    client.User.setGame(gameArray[randomGame]);
+  }, 60000)
 }
+
 
 function forceFetchUsers() {
   logger.info('Force fetching users');

--- a/src/discord.js
+++ b/src/discord.js
@@ -102,6 +102,7 @@ function onMessage(evt) {
   if (!evt.message) return;
   if (client.User.id === evt.message.author.id) return;
   if (evt.message.author.bot) return;
+  if (!evt.message.author.id === nconf.get('OWNER_ID')) return;
 
   if (!evt.message.channel.isPrivate) {
     getGuildPrefix(evt.message.guild.id).then(guildPrefix => {
@@ -189,12 +190,11 @@ function forceSetGame() {
       '@FurBot help',
       '@FurBot info',
       '@FurBot version',
-      'with beans',
+      'with Beans',
       'with Esix',
-      'with Node.JS',
-      'with furries',
-      'with tails',
-      'with paws'
+      'with Furries',
+      'with Tails',
+      'with Paws'
     ];
     let randomGame = Math.floor(Math.random() * gameArray.length);
     client.User.setGame(gameArray[randomGame]);

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -77,7 +77,7 @@ export function getKeys(obj, val) {
   return objects;
 }
 
-export function getImageLink(client, evt, suffix) {
+export function getImageLink(client, evt, suffix, pride) {
   let channel = evt.message.channel;
   let suffixSplit = [];
   if (suffix) suffixSplit = suffix.split(' ');
@@ -85,11 +85,17 @@ export function getImageLink(client, evt, suffix) {
   let imageLink;
   let doPrevious = false;
 
-  if (suffixSplit[0] === 'previous' || suffixSplit[1] === 'previous') doPrevious = true;
+  if (suffixSplit.includes('previous')) doPrevious = true;
 
   if (suffixSplit.length === 2 && !doPrevious) {
     if (isNaN(suffixSplit[0])) suffixSplit[0] = 1;
     imageLink = suffixSplit[1];
+  }
+
+  if (pride) {
+    if (suffixSplit.length === 3 && !doPrevious) {
+      suffixSplit[1] = suffixSplit[2];
+    }
   }
 
   if (doPrevious) {
@@ -115,7 +121,6 @@ export function getImageLink(client, evt, suffix) {
   }
 
   if (suffixSplit.length === 1 && evt.message.attachments.length === 0 && !doPrevious) {
-    console.log(evt.message);
     if (isNaN(suffixSplit[0])) {
       suffixSplit[1] = suffixSplit[0];
       suffixSplit[0] = 1;
@@ -125,7 +130,7 @@ export function getImageLink(client, evt, suffix) {
     imageLink = suffixSplit[1];
   }
 
-  if (suffixSplit.length < 2 && evt.message.attachments.length && !doPrevious) {
+  if (suffixSplit.length < 3 && evt.message.attachments.length && !doPrevious) {
     if (evt.message.attachments[0].url) {
       if (isNaN(suffixSplit[0])) {
         suffixSplit[0] = 1;

--- a/src/redis.js
+++ b/src/redis.js
@@ -120,7 +120,7 @@ export function delBlackListChannel(channel_id) {
 
 export function getGuildPrefix(guild_id) {
   return guildClient.hgetAsync(`guild_${guild_id}`, 'prefix')
-    .then(prefix => prefix || 'f.')
+    .then(prefix => prefix || nconf.get('PREFIX'))
     .timeout(2000)
     .catch(err => {
       sentry(err, 'getGuildPrefix');


### PR DESCRIPTION
# 4.4.6 (March 28th, 2019)

### Features
- [NEW] You can now change FurBot's prefix with the `prefix` command, only users with
`MANAGE SERVER` permissions can use this command. You can only have a single or double
character prefix. Only certain characters are allowed.

### Bug Fixes
- [FIX] Searching for example `cubone` on the lewd commands no longer triggers the blacklist.
- [FIX] You can now use `previous`, image links and attachments on the `pride` image command.
- [FIX] The `word` command now doesn't turn multiple regional_indicator emoji into a Flag.

### Notes
- [NEW] FurBot now scrolls through several Playing statuses displaying some random texts or commands.